### PR TITLE
FEAT: Call the pr-to-main workflow locally no longer tied to 51Degree…

### DIFF
--- a/.github/workflows/nightly-prs-to-main.yml
+++ b/.github/workflows/nightly-prs-to-main.yml
@@ -68,7 +68,7 @@ jobs:
       matrix:
         id: ${{ fromJSON(needs.Get_Pull_Requests.outputs.pull_request_ids) }}
 
-    uses: 51degrees/common-ci/.github/workflows/nightly-pr-to-main.yml@main
+    uses: ./.github/workflows/nightly-pr-to-main.yml
     with:
       repo-name: ${{ inputs.repo-name }}
       org-name: ${{ inputs.org-name }}


### PR DESCRIPTION
…s organization

By calling a local workflow from prs-to-main, whatever repo it exists in will be the same one containing pr-to-main.