### PR TITLE
CLEANUP: Removed the CONTRIBUTOR role from the list of roled eligible for auto merging.

### DIFF
--- a/steps/README.md
+++ b/steps/README.md
@@ -75,7 +75,6 @@ Gets the open PRs for the repo, and sets the ids of valid PRs as an array under 
 A PR is considered valid if it was created by one of the following roles:
 - `OWNER`
 - `COLLABORATOR`
-- `CONTRIBUTOR`
 - `MEMBER`
 or was approved by a member of the 51Degrees Github organisation.
 

--- a/steps/get-pull-requests.ps1
+++ b/steps/get-pull-requests.ps1
@@ -51,7 +51,6 @@ function ShouldRun {
     $Pr = hub api /repos/$OrgName/$RepoName/pulls/$Id | ConvertFrom-Json
     if ($Pr.author_association -eq 'OWNER' -or
         $Pr.author_association -eq 'COLLABORATOR' -or
-        $Pr.author_association -eq 'CONTRIBUTOR' -or
         $Pr.author_association -eq 'MEMBER') {
         # The author is one of the above, so return true
         Write-Information "The creator is '$($Pr.author_association)', so allow automation"


### PR DESCRIPTION
PRs from this role will now require approval.