### PR TITLE
python: ensure installed package is used in tests

### DIFF
--- a/python/run-integration-tests.ps1
+++ b/python/run-integration-tests.ps1
@@ -18,10 +18,10 @@ Push-Location $RepoName
 try {
     foreach ($package in $Packages) {
         Write-Output "Testing $package"
-        Push-Location $package
+        Push-Location $package/tests
         try {
             Write-Output "Running tests in '$pwd'"
-            coverage run -m xmlrunner discover -s tests -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
+            coverage run -m xmlrunner discover -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
             $packageName = Split-Path -Path $pwd -Leaf # Required for location-python, which uses . as package path
             Move-Item -Path .coverage -Destination $repoPath/.coverage.$packageName || $(throw "failed to move coverage report")
         } finally {

--- a/python/run-unit-tests.ps1
+++ b/python/run-unit-tests.ps1
@@ -13,9 +13,9 @@ Push-Location $RepoName
 try {
     foreach ($package in $Packages) {
         Write-Output "Testing $package"
-        Push-Location $package
+        Push-Location $package/tests
         try {
-            coverage run -m xmlrunner discover -s tests -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
+            coverage run -m xmlrunner discover -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
             Move-Item -Path .coverage -Destination $repoPath/.coverage.$package || $(throw "failed to move coverage report")
         } finally {
             Pop-Location


### PR DESCRIPTION
When we run the tests from `tests` directory's parent directory (e.g. `fiftyone_pipeline_core`), the `fiftyone_pipeline_core` sibling directory will be prioritized before the package that was installed here: https://github.com/51degrees/common-ci/blob/main/python/build-project.ps1#L18, or here: https://github.com/51degrees/common-ci/blob/main/python/install-package.ps1. This means that `nightly-publish-main` tests the code from git, instead of the packages. This PR fixes that by running the tests from the `tests` directory, so that the sibling directories aren't seen by them, and they have to use `pip install`-ed packages.