### PR TITLE
Revert "python: ensure installed package is used in tests"

### DIFF
--- a/python/run-integration-tests.ps1
+++ b/python/run-integration-tests.ps1
@@ -18,10 +18,10 @@ Push-Location $RepoName
 try {
     foreach ($package in $Packages) {
         Write-Output "Testing $package"
-        Push-Location $package/tests
+        Push-Location $package
         try {
             Write-Output "Running tests in '$pwd'"
-            coverage run -m xmlrunner discover -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
+            coverage run -m xmlrunner discover -s tests -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
             $packageName = Split-Path -Path $pwd -Leaf # Required for location-python, which uses . as package path
             Move-Item -Path .coverage -Destination $repoPath/.coverage.$packageName || $(throw "failed to move coverage report")
         } finally {

--- a/python/run-unit-tests.ps1
+++ b/python/run-unit-tests.ps1
@@ -13,9 +13,9 @@ Push-Location $RepoName
 try {
     foreach ($package in $Packages) {
         Write-Output "Testing $package"
-        Push-Location $package/tests
+        Push-Location $package
         try {
-            coverage run -m xmlrunner discover -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
+            coverage run -m xmlrunner discover -s tests -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
             Move-Item -Path .coverage -Destination $repoPath/.coverage.$package || $(throw "failed to move coverage report")
         } finally {
             Pop-Location


### PR DESCRIPTION
This reverts commit 4a5c01577eee9481c48a743bc2f40618b98195a5.

Turns out that although we would be testing the local packages this way
- some tests still use relative paths to dependencies, thus it will require more refactorings to fix and ensure all tests work and rely on packages rather than relative paths.