### PR TITLE
Migrate to gh cli

### DIFF
--- a/generate-documentation.ps1
+++ b/generate-documentation.ps1
@@ -20,7 +20,7 @@ if ($GitHubEmail -eq "") {
     $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/monthly-copyright-update.ps1
+++ b/monthly-copyright-update.ps1
@@ -14,7 +14,7 @@ param (
 
 . ./constants.ps1
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-data-file-change.ps1
+++ b/nightly-data-file-change.ps1
@@ -21,7 +21,7 @@ if ($GitHubEmail -eq "") {
     $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-package-update.ps1
+++ b/nightly-package-update.ps1
@@ -21,7 +21,7 @@ if ($GitHubEmail -eq "") {
     $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-pr-to-main_build-and-test.ps1
+++ b/nightly-pr-to-main_build-and-test.ps1
@@ -26,7 +26,7 @@ if ($GitHubEmail -eq "") {
     $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-pr-to-main_compare-performance.ps1
+++ b/nightly-pr-to-main_compare-performance.ps1
@@ -27,7 +27,7 @@ if ($GitHubEmail -eq "") {
     $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-pr-to-main_complete.ps1
+++ b/nightly-pr-to-main_complete.ps1
@@ -22,7 +22,7 @@ if ($GitHubEmail -eq "") {
     $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-pr-to-main_configure-pr.ps1
+++ b/nightly-pr-to-main_configure-pr.ps1
@@ -23,7 +23,7 @@ if ($GitHubEmail -eq "") {
     $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-pr-to-main_get-prs.ps1
+++ b/nightly-pr-to-main_get-prs.ps1
@@ -23,7 +23,7 @@ if ($GitHubEmail -eq "") {
     $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-publish-main_build.ps1
+++ b/nightly-publish-main_build.ps1
@@ -22,7 +22,7 @@ if ($GitHubEmail -eq "") {
   $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-publish-main_configure.ps1
+++ b/nightly-publish-main_configure.ps1
@@ -22,7 +22,7 @@ if ($GitHubEmail -eq "") {
   $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-publish-main_package.ps1
+++ b/nightly-publish-main_package.ps1
@@ -22,7 +22,7 @@ if ($GitHubEmail -eq "") {
   $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-publish-main_prebuild.ps1
+++ b/nightly-publish-main_prebuild.ps1
@@ -22,7 +22,7 @@ if ($GitHubEmail -eq "") {
   $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-publish-main_test.ps1
+++ b/nightly-publish-main_test.ps1
@@ -22,7 +22,7 @@ if ($GitHubEmail -eq "") {
   $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/nightly-submodule-update.ps1
+++ b/nightly-submodule-update.ps1
@@ -21,7 +21,7 @@ if ($GitHubEmail -eq "") {
     $GitHubEmail = $DefaultGitEmail
 }
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 

--- a/steps/checkout-pr.ps1
+++ b/steps/checkout-pr.ps1
@@ -22,11 +22,10 @@ try {
     
     }
 
-    # For the format argument, see https://hub.github.com/hub-pr.1.html
-    $PrTitle = $(hub pr show $PullRequestId -f "%i %H->%B : '%t'")
+    $PrTitle = gh pr view $PullRequestId --json number,baseRefName,headRefName,title --jq '"#\(.number) \(.headRefName)->\(.baseRefName) : \(.title)"'
 
     Write-Output "Checking out PR $PrTitle"
-    hub pr checkout $PullRequestId
+    gh pr checkout $PullRequestId
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }
@@ -43,7 +42,7 @@ try {
         exit $LASTEXITCODE
     }
     
-    $Sha = hub pr show $PullRequestId -f "%sH"
+    $Sha = gh pr view $PullRequestId --json headRefOid --jq '.headRefOid'
     Write-Output "Setting '$VariableName' to '$Sha'"
     Set-Variable -Name $VariableName -Value $Sha -Scope Global
 

--- a/steps/comment-on-issue.ps1
+++ b/steps/comment-on-issue.ps1
@@ -10,4 +10,4 @@ param(
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 
-hub api /repos/$OrgName/$RepoName/issues/$Id/comments -X POST -f `"body=$Message`"
+gh api /repos/$OrgName/$RepoName/issues/$Id/comments -X POST -f "body=$Message"

--- a/steps/compare-performance.ps1
+++ b/steps/compare-performance.ps1
@@ -225,7 +225,7 @@ if ($PlotReady -eq $False) {
 }
 
 # Get all the artifactrs
-$AllArtifacts = $(hub api /repos/$OrgName/$RepoName/actions/artifacts | ConvertFrom-Json).artifacts
+$AllArtifacts = $(gh api /repos/$OrgName/$RepoName/actions/artifacts | ConvertFrom-Json).artifacts
 
 foreach ($Options in $AllOptions) {
     if ($Options.RunPerformance -eq $True) {

--- a/steps/download-artifact.ps1
+++ b/steps/download-artifact.ps1
@@ -12,8 +12,9 @@ param (
     [string]$GitHubToken
 )
 
-$Artifacts = $(hub api /repos/$OrgName/$RepoName/actions/runs/$RunId/artifacts | ConvertFrom-Json).artifacts
-hub api /repos/$OrgName/$RepoName/actions/runs/$RunId/artifacts
+$Response = gh api /repos/$OrgName/$RepoName/actions/runs/$RunId/artifacts
+$Artifacts = $($Response | ConvertFrom-Json).artifacts
+Write-Output $Response
 Write-Output $Artifacts
 
 foreach ($Artifact in $Artifacts) {

--- a/steps/get-pull-requests.ps1
+++ b/steps/get-pull-requests.ps1
@@ -7,13 +7,13 @@ param (
     [string]$GitHubToken
 )
 
-# This token is used by the hub command.
+# This token is used by the gh command.
 Write-Output "Setting GITHUB_TOKEN"
 $env:GITHUB_TOKEN="$GitHubToken"
 
 $RepoPath = [IO.Path]::Combine($pwd, $RepoName)
 
-$OrgUsers = hub api /orgs/$OrgName/members | ConvertFrom-JSON
+$OrgUsers = gh api /orgs/$OrgName/members | ConvertFrom-JSON
 
 function IsOrgUser {
     param (
@@ -47,8 +47,8 @@ function ShouldRun {
         [string]$Id
     )
     $Allowed = $False
-    $Reviews = hub api /repos/$OrgName/$RepoName/pulls/$Id/reviews | ConvertFrom-JSON
-    $Pr = hub api /repos/$OrgName/$RepoName/pulls/$Id | ConvertFrom-Json
+    $Reviews = gh api /repos/$OrgName/$RepoName/pulls/$Id/reviews | ConvertFrom-JSON
+    $Pr = gh api /repos/$OrgName/$RepoName/pulls/$Id | ConvertFrom-Json
     if ($Pr.author_association -eq 'OWNER' -or
         $Pr.author_association -eq 'COLLABORATOR' -or
         $Pr.author_association -eq 'MEMBER') {
@@ -74,7 +74,7 @@ function ShouldRun {
     }
     if ($Pr.requested_reviewers.Count -gt 0) {
         foreach ($Reviewer in $Pr.requested_reviewers) {
-            $User = hub api /users/$($Reviewer.login) | ConvertFrom-Json
+            $User = gh api /users/$($Reviewer.login) | ConvertFrom-Json
             if ($(HasReviewed -UserId $User.id -Reviews $Reviews) -eq $False) {
                 Write-Information "The user '$($User.login)' has not approved, so do not run automation"
                 $Allowed = $False
@@ -89,13 +89,8 @@ Push-Location $RepoPath
 
 try {
 
-    # The format here lists the ids of the PRs with commas
-    $Ids = $(hub pr list -f "%I," -b main)
+    $Ids = gh pr list -B main --json number --jq '.[].number'
     if ($Null -ne $Ids) {
-        # Because of the format we used above, we need to remove the trailing comma.
-        # Then we convert to an array.
-        $Ids = $Ids.Trim(",").Split(",")
-
         $ValidIds = @()
 
         foreach ($Id in $Ids) {

--- a/steps/merge-pr.ps1
+++ b/steps/merge-pr.ps1
@@ -25,12 +25,12 @@ try {
     }
     
     # For the format argument, see https://hub.github.com/hub-pr.1.html
-    $PrTitle = $(hub pr show $PullRequestId -f "%i %H->%B : '%t'")
+    $PrTitle = gh pr view $PullRequestId --json number,baseRefName,headRefName,title --jq '"#\(.number) \(.headRefName)->\(.baseRefName) : \(.title)"'
 
     Write-Output "Merging PR $PrTitle"
-    $Command = "hub api /repos/$OrgName/$RepoName/pulls/$PullRequestId/merge -X PUT -f `"commit_title=Merged Pull Request '$PrTitle'`""
+    $Command = {gh api /repos/$OrgName/$RepoName/pulls/$PullRequestId/merge -X PUT -f "commit_title=Merged Pull Request '$PrTitle'"}
     if ($DryRun -eq $False) {
-        Invoke-Expression $Command
+        & $Command
     }
     else {
         Write-Output "Dry run - not executing the following: $Command"

--- a/steps/pull-request-to-main.ps1
+++ b/steps/pull-request-to-main.ps1
@@ -17,15 +17,15 @@ try {
     $CurrentBranch = $(git rev-parse --abbrev-ref HEAD)
     
     Write-Output "Getting PRs from '$CurrentBranch' to 'main'"
-    $Prs = $(hub pr list -b main -h $CurrentBranch --format "%I%n")
+    $Prs = gh pr list -B main -H $CurrentBranch --json number --jq '.[].number'
 
     Write-Output "There are '$($Prs.Count)' PRs"
 
     if ($Prs.Count -eq 0) {
         Write-Output "Creating pull request"
-        $Command = "hub pull-request --no-edit --message $Message"
+        $Command = {gh pr create --message $Message}
         if ($DryRun -eq $False) {
-            Invoke-Expression $Command
+            & $Command
         }
         else {
             Write-Output "Dry run - not executing the following: $Command"

--- a/steps/update-tag.ps1
+++ b/steps/update-tag.ps1
@@ -30,9 +30,9 @@ try {
     # When creating the release, auto-generate the release notes from the
     # PRs that are included in the changes.
     Write-Output "Creating a GitHub release"
-    $Command = "hub api /repos/$OrgName/$RepoName/releases -X POST -f `"tag_name=$Tag`" -F `"generate_release_notes=true`" -f `"name=Version $Tag`""
+    $Command = {gh api /repos/$OrgName/$RepoName/releases -X POST -f "tag_name=$Tag" -F "generate_release_notes=true" -f "name=Version $Tag"}
     if ($DryRun -eq $False) {
-        Invoke-Expression $Command
+        & $Command
     }
     else {
         Write-Output "Dry run - not executing the following: $Command"


### PR DESCRIPTION
The `hub` utility used before was [deprecated a couple of years ago and is in the process of being removed from GitHub Actions base images](https://github.com/actions/runner-images/issues/8362).