### PR TITLE
Fix gh command output formatting

### DIFF
--- a/steps/checkout-pr.ps1
+++ b/steps/checkout-pr.ps1
@@ -22,7 +22,7 @@ try {
     
     }
 
-    $PrTitle = gh pr view $PullRequestId --json number,baseRefName,headRefName,title --jq '"#\(.number) \(.headRefName)->\(.baseRefName) : \(.title)"'
+    $PrTitle = gh pr view $PullRequestId --json number,headRefName,baseRefName,title -t '#{{.number}} {{.headRefName}}->{{.baseRefName}} : {{.title}}'
 
     Write-Output "Checking out PR $PrTitle"
     gh pr checkout $PullRequestId

--- a/steps/merge-pr.ps1
+++ b/steps/merge-pr.ps1
@@ -24,8 +24,7 @@ try {
     
     }
     
-    # For the format argument, see https://hub.github.com/hub-pr.1.html
-    $PrTitle = gh pr view $PullRequestId --json number,baseRefName,headRefName,title --jq '"#\(.number) \(.headRefName)->\(.baseRefName) : \(.title)"'
+    $PrTitle = gh pr view $PullRequestId --json number,headRefName,baseRefName,title -t '#{{.number}} {{.headRefName}}->{{.baseRefName}} : {{.title}}'
 
     Write-Output "Merging PR $PrTitle"
     $Command = {gh api /repos/$OrgName/$RepoName/pulls/$PullRequestId/merge -X PUT -f "commit_title=Merged Pull Request '$PrTitle'"}


### PR DESCRIPTION
The version of gh command on GitHub Actions seems to have somewhat broken jq filtering, despite version number being identical to the one I used locally. Luckily, using Go templates instead is possible in this case.