### PR TITLE
Pass mandatory arg to `gh pr create`

### DIFF
--- a/steps/pull-request-to-main.ps1
+++ b/steps/pull-request-to-main.ps1
@@ -23,7 +23,7 @@ try {
 
     if ($Prs.Count -eq 0) {
         Write-Output "Creating pull request"
-        $Command = {gh pr create --title $Message --body ''}
+        $Command = {gh pr create --title $Message --body $Message}
         if ($DryRun -eq $False) {
             & $Command
         }


### PR DESCRIPTION
The version of `gh cli` on GitHub Actions runners doesn't seem to accept empty arguments for `--body` flag of `gh pr create`. This PR works around the problem by duplicating the title as the body.