### PR TITLE
Expose `--exclude-regex` parameter for `ctest`.

### DIFF
--- a/cxx/run-unit-tests.ps1
+++ b/cxx/run-unit-tests.ps1
@@ -6,8 +6,10 @@ param(
     [string]$Name,
     [string]$Configuration = "Release",
     [string]$Arch = "x64",
-    [string]$BuildMethod = "cmake"
+    [string]$BuildMethod = "cmake",
+    [string]$ExcludeRegex = ".*Performance|Integration|Example.*"
 )
+
 $RepoPath = [IO.Path]::Combine($pwd, $RepoName)
 if ($BuildMethod -eq "cmake") {
 
@@ -20,7 +22,7 @@ if ($BuildMethod -eq "cmake") {
 
         Write-Output "Testing $Name"
 
-        ctest -C $Configuration -T test --no-compress-output --output-junit "$RepoPath/test-results/unit/$Name.xml" --exclude-regex ".*Performance|Integration|Example.*"
+        ctest -C $Configuration -T test --no-compress-output --output-junit "$RepoPath/test-results/unit/$Name.xml" --exclude-regex $ExcludeRegex
     }
     finally {
 


### PR DESCRIPTION
### Why?

To allow for the customization required by [device-detection-cxx](https://github.com/51Degrees/device-detection-cxx) repo:
see excerpt from https://github.com/51Degrees/device-detection-cxx/blob/main/ci/run-unit-tests.ps1#L19-L21 :
```ps1
# Instead of calling the common CTest script, we want to allow the inclusion of tests with Performance in the name.
# This is because HighPerformance is the name of a configuration.
ctest -C $Configuration -T test --no-compress-output --output-junit "../test-results/unit/$Name.xml" --exclude-regex ".*Example.*"
```