### PR TITLE
Run python tests in tox environment

### DIFF
--- a/python/run-integration-tests.ps1
+++ b/python/run-integration-tests.ps1
@@ -21,8 +21,10 @@ try {
         Push-Location $package
         try {
             Write-Output "Running tests in '$pwd'"
-            coverage run -m xmlrunner discover -s tests -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
+            # coverage run -m xmlrunner discover -s tests -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
             $packageName = Split-Path -Path $pwd -Leaf # Required for location-python, which uses . as package path
+            $coverageOutputFile = Join-Path -Path $commonTestResults -ChildPath "$packageName.xml"
+            python -m tox -e py -- --junit-xml=$coverageOutputFile || $($testsFailed = $true)
             Move-Item -Path .coverage -Destination $repoPath/.coverage.$packageName || $(throw "failed to move coverage report")
         } finally {
             Pop-Location

--- a/python/run-unit-tests.ps1
+++ b/python/run-unit-tests.ps1
@@ -15,7 +15,10 @@ try {
         Write-Output "Testing $package"
         Push-Location $package
         try {
-            coverage run -m xmlrunner discover -s tests -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
+            Write-Output "Running tests in '$pwd'"
+            # coverage run -m xmlrunner discover -s tests -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
+            $coverageOutputFile = Join-Path -Path $commonTestResults -ChildPath "$package.xml"
+            python -m tox -e py -- --junit-xml=$coverageOutputFile || $($testsFailed = $true)
             Move-Item -Path .coverage -Destination $repoPath/.coverage.$package || $(throw "failed to move coverage report")
         } finally {
             Pop-Location


### PR DESCRIPTION
In this pull request, changes have been made to the way Python tests are run.
Previously, `coverage` was used with `xmlrunner` to run the tests.
Now, tests are being run within a `tox` environment using `pytest`.
