### PR TITLE
Add dir name format for unit tests

### DIFF
--- a/dotnet/run-unit-tests.ps1
+++ b/dotnet/run-unit-tests.ps1
@@ -7,6 +7,7 @@ param(
     [string]$Configuration = "Release",
     [string]$Arch = "x64",
     [string]$BuildMethod="dotnet",
+    [string]$DirNameFormat = "*bin*",
     [string]$Filter,
     [string]$OutputFolder = "unit"
 )
@@ -25,7 +26,7 @@ try {
     Write-Output "Testing '$Name'"
     if ($BuildMethod -eq "dotnet"){
         Get-ChildItem -Path $RepoPath -Recurse -File | ForEach-Object {
-            if (($_.DirectoryName -like "*bin*" -and $_.Name -notlike $skipPattern) -and ($_.Name -match "$Filter")) {
+            if (($_.DirectoryName -like $DirNameFormat -and $_.Name -notlike $skipPattern) -and ($_.Name -match "$Filter")) {
                 Write-Output "Testing Assembly: '$_'"
                 dotnet test $_.FullName --results-directory $TestResultPath --blame-crash -l "trx" || $($script:ok = $false)
             }

--- a/dotnet/run-unit-tests.ps1
+++ b/dotnet/run-unit-tests.ps1
@@ -25,6 +25,7 @@ try {
     $skipPattern = "*performance*"
     Write-Output "Testing '$Name'"
     if ($BuildMethod -eq "dotnet"){
+        Write-Output "Looking for '$Filter' in directories like '$DirNameFormat'"
         Get-ChildItem -Path $RepoPath -Recurse -File | ForEach-Object {
             if (($_.DirectoryName -like $DirNameFormat -and $_.Name -notlike $skipPattern) -and ($_.Name -match "$Filter")) {
                 Write-Output "Testing Assembly: '$_'"

--- a/dotnet/run-unit-tests.ps1
+++ b/dotnet/run-unit-tests.ps1
@@ -7,7 +7,8 @@ param(
     [string]$Configuration = "Release",
     [string]$Arch = "x64",
     [string]$BuildMethod="dotnet",
-    [string]$DirNameFormat = "*bin*",
+    [string]$DirNameFormatForDotnet = "*bin*",
+    [string]$DirNameFormatForNotDotnet = "*\bin\*",
     [string]$Filter,
     [string]$OutputFolder = "unit"
 )
@@ -25,18 +26,18 @@ try {
     $skipPattern = "*performance*"
     Write-Output "Testing '$Name'"
     if ($BuildMethod -eq "dotnet"){
-        Write-Output "Looking for '$Filter' in directories like '$DirNameFormat'"
+        Write-Output "[dotnet] => Looking for '$Filter' in directories like '$DirNameFormatForDotnet'"
         Get-ChildItem -Path $RepoPath -Recurse -File | ForEach-Object {
-            if (($_.DirectoryName -like $DirNameFormat -and $_.Name -notlike $skipPattern) -and ($_.Name -match "$Filter")) {
+            if (($_.DirectoryName -like $DirNameFormatForDotnet -and $_.Name -notlike $skipPattern) -and ($_.Name -match "$Filter")) {
                 Write-Output "Testing Assembly: '$_'"
                 dotnet test $_.FullName --results-directory $TestResultPath --blame-crash -l "trx" || $($script:ok = $false)
             }
         }
     }
     else{
-
+        Write-Output "[$BuildMethod] ~> Looking for '$Filter' in directories like '$DirNameFormatForNotDotnet'"
         Get-ChildItem -Path $RepoPath -Recurse -File | ForEach-Object {
-            if (($_.DirectoryName -like "*\bin\*" -and $_.Name -notlike $skipPattern) -and ($_.Name -match "$Filter")) {
+            if (($_.DirectoryName -like $DirNameFormatForNotDotnet -and $_.Name -notlike $skipPattern) -and ($_.Name -match "$Filter")) {
                 Write-Output "Testing Assembly: '$_'"
                 & vstest.console.exe $_.FullName /Logger:trx /ResultsDirectory:$TestResultPath || $($script:ok = $false)
             }


### PR DESCRIPTION
### Changes
- Expose 2 new parameters: `DirNameFormatForDotnet` and `DirNameFormatForNotDotnet` --- to allow overriding where the test files (DLL/solution) are searched for.
- Add some logging.

### Why
To allow using `dotnet test` on the solution rather than separate DLLs.
This enables running the tests that depend on executable projects, as DLLs can not link against EXE files.

### Expected use site
https://github.com/51Degrees/device-detection-dotnet-examples/pull/62 , more specifically:
- https://github.com/postindustria-tech/device-detection-dotnet-examples/commit/079ead756d1cc3a2aaadb5770e75c3132446f659
- https://github.com/postindustria-tech/device-detection-dotnet-examples/commit/d542a78957927f9550f36e76fd465b0e010a4d25