### PR TITLE
[dotnet] Expose `DirNameFormat` params of `run-unit-tests.ps1` on `run-integration-tests.ps1`

### DIFF
--- a/dotnet/run-integration-tests.ps1
+++ b/dotnet/run-integration-tests.ps1
@@ -7,9 +7,11 @@ param(
     [string]$Configuration = "Release",
     [string]$Arch = "x64",
     [string]$BuildMethod = "msbuild",
+    [string]$DirNameFormatForDotnet = "*bin*",
+    [string]$DirNameFormatForNotDotnet = "*\bin\*",
     [Parameter(Mandatory=$true)]
     [string]$Filter
 )
 
-./dotnet/run-unit-tests.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod -Filter $Filter -OutputFolder "integration"
+./dotnet/run-unit-tests.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod -Filter $Filter -OutputFolder "integration" -DirNameFormatForDotnet $DirNameFormatForDotnet -DirNameFormatForNotDotnet $DirNameFormatForNotDotnet
 


### PR DESCRIPTION
### Changes
- Make the 2 properties already available in `run-unit-tests.ps1` --- `DirNameFormatForDotnet` and `DirNameFormatForNotDotnet` --- accessible as parameters of `run-integration-tests.ps1`

### Relation to previous PRs
- Expands on https://github.com/51Degrees/common-ci/pull/53

### Expected use case
- https://github.com/postindustria-tech/device-detection-dotnet/commit/80c2c0381f0b6824872b0f744d150571cdf1c6ed