### PR TITLE
Add `common-ci-ref` input to some workflows.

### DIFF
--- a/.github/workflows/nightly-pr-to-main.yml
+++ b/.github/workflows/nightly-pr-to-main.yml
@@ -28,6 +28,10 @@ on:
       cache-assets:
         default: false
         type: boolean
+      common-ci-ref:
+        required: false
+        type: string
+        default: ''
     secrets:
       token:
         required: true
@@ -48,6 +52,7 @@ jobs:
         with:
           repository: ${{ inputs.org-name }}/common-ci
           path: common
+          ref: ${{ inputs.common-ci-ref }}
 
       - name: Hash the Asset Cache Key
         id: hash-asset-cache-key
@@ -91,6 +96,7 @@ jobs:
         with:
           repository: ${{ inputs.org-name }}/common-ci
           path: common
+          ref: ${{ inputs.common-ci-ref }}
 
       - name: Install Runtime
         if: matrix.options.Language != '' && matrix.options.LanguageVersion != ''
@@ -167,6 +173,7 @@ jobs:
         with:
           repository: ${{ inputs.org-name }}/common-ci
           path: common
+          ref: ${{ inputs.common-ci-ref }}
 
       - name: Download Performance Artifact
         uses: actions/download-artifact@v3
@@ -212,6 +219,7 @@ jobs:
         with:
           repository: ${{ inputs.org-name }}/common-ci
           path: common
+          ref: ${{ inputs.common-ci-ref }}
 
       - name: Complete
         shell: pwsh

--- a/.github/workflows/nightly-prs-to-main.yml
+++ b/.github/workflows/nightly-prs-to-main.yml
@@ -25,6 +25,10 @@ on:
       cache-assets:
         default: false
         type: boolean
+      common-ci-ref:
+        required: false
+        type: string
+        default: ''
       prs: # Comma-separated list of pull request IDs to build
         required: false
         type: string
@@ -46,6 +50,7 @@ jobs:
         with:
           repository: ${{ inputs.org-name }}/common-ci
           path: common
+          ref: ${{ inputs.common-ci-ref }}
 
       # Get all the pull requests into main, and output the ids
       - name: Get Pull Requests
@@ -82,6 +87,7 @@ jobs:
       email: ${{ inputs.email }}
       dryrun: ${{ inputs.dryrun }}
       cache-assets: ${{ inputs.cache-assets }}
+      common-ci-ref: ${{ inputs.common-ci-ref }}
     secrets: 
       token: ${{ secrets.token }}
       asset-keys: ${{ secrets.asset-keys }}

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -28,6 +28,10 @@ on:
       cache-assets:
         default: false
         type: boolean
+      common-ci-ref:
+        required: false
+        type: string
+        default: ''
     secrets:
       # PAT that we use to authenticate on behalf of GitHub Actions.
       token:
@@ -51,6 +55,7 @@ jobs:
         with:
           repository: ${{ inputs.org-name }}/common-ci
           path: common
+          ref: ${{ inputs.common-ci-ref }}
 
       - name: Hash the Asset Cache Key
         id: hash-asset-cache-key
@@ -93,6 +98,7 @@ jobs:
         with:
           repository: ${{ inputs.org-name }}/common-ci
           path: common
+          ref: ${{ inputs.common-ci-ref }}
 
       - name: Install Runtime
         if: matrix.options.Language != '' && matrix.options.LanguageVersion != ''
@@ -136,6 +142,7 @@ jobs:
         with:
           repository: ${{ inputs.org-name }}/common-ci
           path: common
+          ref: ${{ inputs.common-ci-ref }}
 
       - name: Download Package Artifacts
         if: ${{ success() }}
@@ -184,6 +191,7 @@ jobs:
         with:
           repository: ${{ inputs.org-name }}/common-ci
           path: common
+          ref: ${{ inputs.common-ci-ref }}
 
       - name: Download Package Artifact
         if: ${{ success() && matrix.options.packagerequirement }}
@@ -250,6 +258,7 @@ jobs:
         with:
           repository: ${{ inputs.org-name }}/common-ci
           path: common
+          ref: ${{ inputs.common-ci-ref }}
 
       - name: Download Package Artifact
         if: ${{ success() }}


### PR DESCRIPTION
### Changes
- Add `common-ci-ref` parameter to:
  + nightly-pr-to-main.yml
  + nightly-prs-to-main.yml
  + nightly-publish-main.yml
- Use this parameter to specify a reference for `common-ci` to be checked out at.

### Why?
This allows for testing scripts modifications in platform-specific repositories (e.g. [device-detection-dotnet](https://github.com/51Degrees/device-detection-dotnet)) that depend on patches to this one ([common-ci](https://github.com/51Degrees/common-ci)) while avoiding collisions of concurrent writing to the default branch (i.e. `main`) by specifying the reference to be checked out.

Use case: https://github.com/postindustria-tech/device-detection-dotnet/commit/1b2171ba5c087ea19421479ca7dfb8b8950cc8db#diff-84e446dbbc64d7739dd0bef9d3bff145a8139a8bbabe92bc9e24cc3edf0c1e54R17