### PR TITLE
Generate pre-publish requirements file to install prebuilt packages

### DIFF
--- a/python/run-integration-tests.ps1
+++ b/python/run-integration-tests.ps1
@@ -14,6 +14,29 @@ $commonTestResults = New-Item -ItemType directory -Path $RepoName/test-results/i
 $repoPath = Get-Item -Path $RepoName
 $testsFailed = $false
 
+# used only in nightly-publish-main workflow
+if ($env:GITHUB_JOB -eq "Test") {
+    # this part generates a requirements file that is used by the integration
+    # tests to install built packages from the local filesystem
+
+    $packagesDir = Get-Item -Path package
+
+    # get all the tar.gz files in the package directory
+    $tarFiles = Get-ChildItem -Path $packagesDir -Filter *.tar.gz
+
+    $preRequirementsFile = Join-Path -Path $packagesDir -ChildPath "pre-publish-requirements.txt"
+
+    # if doesn't exist, create a requirements file
+    if (!(Test-Path $preRequirementsFile)) {
+        New-Item -Path $preRequirementsFile -ItemType "file"
+    }
+
+    $tarFiles | ForEach-Object {
+        # get the absolute path to the package and append it to the requirements file
+        $_.FullName | Out-File -Append -FilePath $preRequirementsFile
+    }
+}
+
 Push-Location $RepoName
 try {
     foreach ($package in $Packages) {
@@ -24,7 +47,8 @@ try {
             # coverage run -m xmlrunner discover -s tests -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
             $packageName = Split-Path -Path $pwd -Leaf # Required for location-python, which uses . as package path
             $coverageOutputFile = Join-Path -Path $commonTestResults -ChildPath "$packageName.xml"
-            python -m tox -e py -- --junit-xml=$coverageOutputFile || $($testsFailed = $true)
+            $toxEnv = $env:GITHUB_JOB -eq "Build-and-Test" ? "py" : "pre-publish"
+            python -m tox -e $toxEnv -- --junit-xml=$coverageOutputFile || $($testsFailed = $true)
             Move-Item -Path .coverage -Destination $repoPath/.coverage.$packageName || $(throw "failed to move coverage report")
         } finally {
             Pop-Location

--- a/python/run-unit-tests.ps1
+++ b/python/run-unit-tests.ps1
@@ -18,7 +18,8 @@ try {
             Write-Output "Running tests in '$pwd'"
             # coverage run -m xmlrunner discover -s tests -p 'test*.py' -o $commonTestResults || $($testsFailed = $true)
             $coverageOutputFile = Join-Path -Path $commonTestResults -ChildPath "$package.xml"
-            python -m tox -e py -- --junit-xml=$coverageOutputFile || $($testsFailed = $true)
+            $toxEnv = $env:GITHUB_JOB -eq "Build-and-Test" ? "py" : "pre-publish"
+            python -m tox -e $toxEnv -- --junit-xml=$coverageOutputFile || $($testsFailed = $true)
             Move-Item -Path .coverage -Destination $repoPath/.coverage.$package || $(throw "failed to move coverage report")
         } finally {
             Pop-Location


### PR DESCRIPTION
This generated file will be used by tox to install all prebuilt packages, but only on `publish` pipeline