### PR TITLE
Add `build`, python build frontend

### DIFF
--- a/python/build-package-pypi.ps1
+++ b/python/build-package-pypi.ps1
@@ -14,15 +14,19 @@ try {
     # Should probably be done in setup-environment.ps1, but it isn't called by
     # build-package.ps1, so doing it here for now
     pip install --upgrade pip
-    pip install setuptools wheel Cython || $(throw "pip install failed")
+    pip install setuptools wheel build Cython || $(throw "pip install failed")
 
     foreach ($package in $Packages) {
         Write-Output "Packaging $package"
         Push-Location $package
         try {
             $Version | Out-File version.txt
-            python setup.py sdist || $(throw "failed to package $package")
-            Move-Item -Path dist/*.tar.gz -Destination $packagesDir || $(throw "failed to move $package package")
+            if ($package -eq "fiftyone_devicedetection_onpremise") {
+                python setup.py sdist || $(throw "failed to build package $package")
+            } else {
+                python -m build || $(throw "failed to build package $package")
+            }
+            Move-Item -Path dist/* -Destination $packagesDir || $(throw "failed to move $package package")
         } finally {
             Pop-Location
         }


### PR DESCRIPTION
Command to build distribution was replaced from outdated `setup.py` to modern python's `build` frontend (for most packages, onpremise has conflicts due to package layout)