### PR TITLE
Whitelist Automation51D user when getting PRs

### DIFF
--- a/steps/get-pull-requests.ps1
+++ b/steps/get-pull-requests.ps1
@@ -51,7 +51,8 @@ function ShouldRun {
     $Pr = gh api /repos/$OrgName/$RepoName/pulls/$Id | ConvertFrom-Json
     if ($Pr.author_association -eq 'OWNER' -or
         $Pr.author_association -eq 'COLLABORATOR' -or
-        $Pr.author_association -eq 'MEMBER') {
+        $Pr.author_association -eq 'MEMBER' -or
+        $Pr.user.login -eq 'Automation51D') {
         # The author is one of the above, so return true
         Write-Information "The creator is '$($Pr.author_association)', so allow automation"
         $Allowed = $True


### PR DESCRIPTION
In private repos author_association is sometimes wrong for Automation51D, so we whitelist the user as a special case.