### PR TITLE
compare-performance: fetch more artifacts

### DIFF
--- a/steps/compare-performance.ps1
+++ b/steps/compare-performance.ps1
@@ -231,7 +231,7 @@ if ($PlotReady -eq $False) {
 }
 
 # Get all the artifactrs
-$AllArtifacts = $(gh api /repos/$OrgName/$RepoName/actions/artifacts | ConvertFrom-Json).artifacts
+$AllArtifacts = $(gh api -X GET -f per_page=90 /repos/$OrgName/$RepoName/actions/artifacts | ConvertFrom-Json).artifacts
 
 foreach ($Options in $AllOptions) {
     if ($Options.RunPerformance -eq $True) {


### PR DESCRIPTION
We need to ensure we have at least 10 `performance_results_passed` artifacts