### PR TITLE
Remove setup-environment from publish's build step

### DIFF
--- a/nightly-publish-main_build.ps1
+++ b/nightly-publish-main_build.ps1
@@ -39,14 +39,6 @@ if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }
 
-Write-Output "::group::Setup Environment"
-./steps/run-repo-script.ps1 -RepoName $RepoName -OrgName $OrgName -ScriptName "setup-environment.ps1" -Options $Options -DryRun $DryRun
-Write-Output "::endgroup::"
-
-if ($LASTEXITCODE -ne 0) {
-    exit $LASTEXITCODE
-}
-
 Write-Output "::group::Build Package"
 ./steps/run-repo-script.ps1 -RepoName $RepoName -OrgName $OrgName -ScriptName "build-package.ps1" -Options $Options -DryRun $DryRun
 Write-Output "::endgroup::"


### PR DESCRIPTION
Most setup-environment scripts depend on `options.json` values which are not present in publish's `Build` job. Repos that need to setup environment before the build should call setup-environment as part of the build-package script.