### PR TITLE
Remove old references during dotnet package update.

### DIFF
--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -36,8 +36,8 @@ try {
 
                     Write-Output "Updating '$PackageName' from '$MajorVersion.$MinorVersion.$PatchVersion' to $($HighestPatch.Version)"
 
+                    dotnet remove $Project.FullName package $PackageName
                     dotnet add $Project.FullName package $PackageName -v $HighestPatch.Version
-                    
                 }
             }
             else {


### PR DESCRIPTION
### Changes
- Remove old references during dotnet package update.

### Why
- https://github.com/51Degrees/device-detection-dotnet-examples/issues/229