### PR TITLE
node: use a loop in install-packages

### DIFF
--- a/node/install-package.ps1
+++ b/node/install-package.ps1
@@ -5,7 +5,9 @@ param (
 
 Push-Location $RepoName
 
-npm install (Get-ChildItem -Path ../package -Filter *.tgz) || $(throw "npm install failed")
+Get-ChildItem -Path ../package -Filter *.tgz | ForEach-Object {
+    npm install $_ || $(throw "npm install failed")
+}
 
 Pop-Location
 


### PR DESCRIPTION
NPM in Node 22 seems to have changed the way it parses command line arguments. NPM consideres everything we pass after `install` to be a single argument. Using a loop instead should work around the issue.