### PR TITLE
Fix `run restore before running` `dotnet list --outdated`

### DIFF
--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -124,6 +124,10 @@ try {
                 }
             }
         }
+    
+        Write-Output "===== ===== ====="
+        Write-Output "Restore other projects for futher updates...."
+        dotnet restore $ProjectDir
     }
     if ($LASTEXITCODE -eq 0) {
         Write-Output "========= ========= ========="

--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -36,9 +36,9 @@ try {
         $ProjectPackagesOutdated = (ConvertFrom-Json -InputObject (-Join $ProjectPackagesOutdatedRaw))
         Write-Debug (ConvertTo-Json -InputObject $ProjectPackagesOutdated -Depth 6)
 
-        if ($ProjectPackagesOutdated.ContainsKey("problems")) {
+        if ($null -ne $ProjectPackagesOutdated.problems) {
             Write-Warning "❌ Problems:"
-            Write-Warning (ConvertTo-Json -InputObject $ProjectPackagesOutdated["problems"])
+            Write-Warning (ConvertTo-Json -InputObject $ProjectPackagesOutdated.problems)
             break
         }
 

--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -16,7 +16,13 @@ try {
     
     dotnet restore $ProjectDir
 
-    foreach ($ProjectFile in $(Get-ChildItem -Path $pwd -Filter $Filter -Recurse -ErrorAction SilentlyContinue -Force)) {
+    Write-Output "========= ========= ========="
+    Write-Output "LOOKING FOR PROJECTS..."
+    $ProjectsToCheck = $(Get-ChildItem -Path $pwd -Filter $Filter -Recurse -ErrorAction SilentlyContinue -Force)
+    Write-Output "FOUND ($($ProjectsToCheck.count)):"
+    Write-Output $($ProjectsToCheck | Select-Object -ExpandProperty FullName)
+
+    foreach ($ProjectFile in $ProjectsToCheck) {
         Write-Output "========= ========= ========="
         Write-Output $ProjectFile.FullName
 

--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -24,6 +24,7 @@ try {
 
     foreach ($ProjectFile in $ProjectsToCheck) {
         Write-Output "========= ========= ========="
+        Write-Output "LASTEXITCODE = $LASTEXITCODE"
         Write-Output $ProjectFile.FullName
 
         $ProjectPackagesOutdatedRaw = (dotnet list $ProjectFile.FullName package --format json --outdated --highest-patch)

--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -62,7 +62,9 @@ try {
             }
         }
         if ($RequestedPackages.Count -eq 0) {
+            Write-Output "LASTEXITCODE = $LASTEXITCODE"
             Write-Output "✅ NO UPDATES"
+            Write-Output "LASTEXITCODE = $LASTEXITCODE"
             continue
         }
         Write-Output "NECESSARY UPDATES:"

--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -27,6 +27,7 @@ try {
         Write-Output $ProjectFile.FullName
         Write-Output ""
         
+        # Explicitly restore the project in case `dotnet restore $ProjectDir` above failed to find it.
         dotnet restore $ProjectFile.FullName
 
         $ProjectPackagesOutdatedRaw = (dotnet list $ProjectFile.FullName package --format json --outdated --highest-patch)

--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -121,6 +121,11 @@ try {
     }
     Write-Output "========= ========= ========="
 }
+catch {
+    Write-Output "An error occurred:"
+    Write-Output $_
+    Write-Output "========= ========= ========="
+}
 finally {
 
     Write-Output "Leaving '$RepoPath'"

--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -25,6 +25,9 @@ try {
     foreach ($ProjectFile in $ProjectsToCheck) {
         Write-Output "========= ========= ========="
         Write-Output $ProjectFile.FullName
+        Write-Output ""
+        
+        dotnet restore $ProjectFile.FullName
 
         $ProjectPackagesOutdatedRaw = (dotnet list $ProjectFile.FullName package --format json --outdated --highest-patch)
         if ($ProjectPackagesOutdatedRaw[0][0] -ne '{') {
@@ -124,10 +127,6 @@ try {
                 }
             }
         }
-    
-        Write-Output "===== ===== ====="
-        Write-Output "Restore other projects for futher updates...."
-        dotnet restore $ProjectDir
     }
     if ($LASTEXITCODE -eq 0) {
         Write-Output "========= ========= ========="

--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -122,15 +122,17 @@ try {
     Write-Output "========= ========= ========="
 }
 catch {
+    Write-Output "░░░░░░░░░ ░░░░░░░░░ ░░░░░░░░░ ░░░░░░░░░ ░░░░░░░░░"
     Write-Output "An error occurred:"
     Write-Output $_
-    Write-Output "========= ========= ========="
 }
 finally {
-
+    Write-Output "░░░░░░░░░ ░░░░░░░░░ ░░░░░░░░░ ░░░░░░░░░ ░░░░░░░░░"
+    Write-Output "In [run-update-dependencies.ps1]:"
+    Write-Output "LASTEXITCODE = $LASTEXITCODE"
+    Write-Output ""
     Write-Output "Leaving '$RepoPath'"
     Pop-Location
-
 }
 
 exit $LASTEXITCODE


### PR DESCRIPTION
### Changes

- Print projects list before iteration.
- Restore each project individually before querying for outdated packages.
- Treat query problems as errors -- print and break.
- Check for errors when printing final separator.

### Why

- ❌ https://github.com/51Degrees/device-detection-dotnet/actions/runs/11116130174/job/30885845149 