### PR TITLE
FEAT: Added the option to pass in the branch to use.

### DIFF
--- a/.github/workflows/nightly-prs-to-main.yml
+++ b/.github/workflows/nightly-prs-to-main.yml
@@ -88,7 +88,7 @@ jobs:
           ./nightly-pull-requests.get-prs.ps1 `
           -RepoName ${{ inputs.repo-name }} `
           -OrgName ${{ inputs.org-name }} `
-          -Branch ${{ inputs.branch != '' && github.ref_name || inputs.branch }} `
+          -Branch ${{ inputs.branch != '' && inputs.branch || github.ref_name }} `
           -GitHubToken ${{ secrets.token }} `
           -GitHubOutput $Env:GITHUB_OUTPUT
     outputs:

--- a/.github/workflows/nightly-prs-to-main.yml
+++ b/.github/workflows/nightly-prs-to-main.yml
@@ -28,6 +28,9 @@ on:
         default: ''
       prs: # Comma-separated list of pull request IDs to build
         type: string
+      branch: # Branch to use if not one calling this
+        type: string
+        default: ''
     secrets:
       token:
         required: true
@@ -85,7 +88,7 @@ jobs:
           ./nightly-pull-requests.get-prs.ps1 `
           -RepoName ${{ inputs.repo-name }} `
           -OrgName ${{ inputs.org-name }} `
-          -Branch ${{ github.ref_name }} `
+          -Branch ${{ inputs.branch != '' && github.ref_name || inputs.branch }} `
           -GitHubToken ${{ secrets.token }} `
           -GitHubOutput $Env:GITHUB_OUTPUT
     outputs:

--- a/.github/workflows/nightly-prs-to-main.yml
+++ b/.github/workflows/nightly-prs-to-main.yml
@@ -112,4 +112,5 @@ jobs:
       dryrun: ${{ inputs.dryrun }}
       cache-assets: ${{ inputs.cache-assets }}
       common-ci-ref: ${{ inputs.common-ci-ref }}
+      branch: ${{ inputs.branch }}
     secrets: inherit

--- a/.github/workflows/nightly-pull-request.yml
+++ b/.github/workflows/nightly-pull-request.yml
@@ -144,7 +144,7 @@ jobs:
           ./nightly-pull-request.build-and-test.ps1 `
           -RepoName ${{ inputs.repo-name }} `
           -OrgName ${{ inputs.org-name }} `
-          -Branch ${{ inputs.branch != '' && github.ref_name || inputs.branch }} `
+          -Branch ${{ inputs.branch != '' && inputs.branch || github.ref_name }} `
           -GitHubToken ${{ secrets.token }} `
           -GitHubOutput $Env:GITHUB_OUTPUT `
           -PullRequestId ${{ inputs.pull-request-id }} `
@@ -215,7 +215,7 @@ jobs:
           ./nightly-pull-request.compare-performance.ps1 `
           -RepoName ${{ inputs.repo-name }} `
           -OrgName ${{ inputs.org-name }} `
-          -Branch ${{ inputs.branch != '' && github.ref_name || inputs.branch }} `
+          -Branch ${{ inputs.branch != '' && inputs.branch || github.ref_name }} `
           -GitHubToken ${{ secrets.token }} `
           -GitHubOutput $Env:GITHUB_OUTPUT `
           -PullRequestId ${{ inputs.pull-request-id }} `

--- a/.github/workflows/nightly-pull-request.yml
+++ b/.github/workflows/nightly-pull-request.yml
@@ -96,7 +96,7 @@ jobs:
           ./nightly-pull-request.configure-pr.ps1 `
           -RepoName ${{ inputs.repo-name }} `
           -OrgName ${{ inputs.org-name }} `
-          -Branch ${{ inputs.branch != '' && github.ref_name || inputs.branch }} `
+          -Branch ${{ inputs.branch != '' && inputs.branch || github.ref_name }} `
           -GitHubToken ${{ secrets.token }} `
           -GitHubOutput $Env:GITHUB_OUTPUT `
           -PullRequestId ${{ inputs.pull-request-id }} `

--- a/.github/workflows/nightly-pull-request.yml
+++ b/.github/workflows/nightly-pull-request.yml
@@ -27,6 +27,9 @@ on:
       common-ci-ref:
         type: string
         default: ''
+      branch: # Branch to use if not one calling this
+        type: string
+        default: ''
     secrets:
       token:
         required: true
@@ -93,7 +96,7 @@ jobs:
           ./nightly-pull-request.configure-pr.ps1 `
           -RepoName ${{ inputs.repo-name }} `
           -OrgName ${{ inputs.org-name }} `
-          -Branch ${{ github.ref_name }} `
+          -Branch ${{ inputs.branch != '' && github.ref_name || inputs.branch }} `
           -GitHubToken ${{ secrets.token }} `
           -GitHubOutput $Env:GITHUB_OUTPUT `
           -PullRequestId ${{ inputs.pull-request-id }} `
@@ -141,7 +144,7 @@ jobs:
           ./nightly-pull-request.build-and-test.ps1 `
           -RepoName ${{ inputs.repo-name }} `
           -OrgName ${{ inputs.org-name }} `
-          -Branch ${{ github.ref_name }} `
+          -Branch ${{ inputs.branch != '' && github.ref_name || inputs.branch }} `
           -GitHubToken ${{ secrets.token }} `
           -GitHubOutput $Env:GITHUB_OUTPUT `
           -PullRequestId ${{ inputs.pull-request-id }} `
@@ -212,7 +215,7 @@ jobs:
           ./nightly-pull-request.compare-performance.ps1 `
           -RepoName ${{ inputs.repo-name }} `
           -OrgName ${{ inputs.org-name }} `
-          -Branch ${{ github.ref_name }} `
+          -Branch ${{ inputs.branch != '' && github.ref_name || inputs.branch }} `
           -GitHubToken ${{ secrets.token }} `
           -GitHubOutput $Env:GITHUB_OUTPUT `
           -PullRequestId ${{ inputs.pull-request-id }} `

--- a/.github/workflows/nightly-pull-requests.yml
+++ b/.github/workflows/nightly-pull-requests.yml
@@ -25,6 +25,9 @@ on:
         default: ''
       prs: # Comma-separated list of pull request IDs to build
         type: string
+      branch: # Branch to use if not one calling this
+        type: string
+        default: ''
     secrets:
       token:
         required: true
@@ -82,7 +85,7 @@ jobs:
           ./nightly-pull-requests.get-prs.ps1 `
           -RepoName ${{ inputs.repo-name }} `
           -OrgName ${{ inputs.org-name }} `
-          -Branch ${{ github.ref_name }} `
+          -Branch ${{ inputs.branch != '' && github.ref_name || inputs.branch }} `
           -GitHubToken ${{ secrets.token }} `
           -GitHubOutput $Env:GITHUB_OUTPUT
     outputs:

--- a/.github/workflows/nightly-pull-requests.yml
+++ b/.github/workflows/nightly-pull-requests.yml
@@ -109,4 +109,5 @@ jobs:
       dryrun: ${{ inputs.dryrun }}
       cache-assets: ${{ inputs.cache-assets }}
       common-ci-ref: ${{ inputs.common-ci-ref }}
+      branch: ${{ inputs.branch }}
     secrets: inherit

--- a/.github/workflows/nightly-pull-requests.yml
+++ b/.github/workflows/nightly-pull-requests.yml
@@ -85,7 +85,7 @@ jobs:
           ./nightly-pull-requests.get-prs.ps1 `
           -RepoName ${{ inputs.repo-name }} `
           -OrgName ${{ inputs.org-name }} `
-          -Branch ${{ inputs.branch != '' && github.ref_name || inputs.branch }} `
+          -Branch ${{ inputs.branch != '' && inputs.branch || github.ref_name }} `
           -GitHubToken ${{ secrets.token }} `
           -GitHubOutput $Env:GITHUB_OUTPUT
     outputs:


### PR DESCRIPTION
Adds the optional input parameter of 'branch' to the PR workflows.
If the option is not passed, then the default of `github.ref_name` is used.
This is required in situations where the triggering reference is not one that can be pulled, e.g. a pull request where the id is used as the ref.