### PR TITLE
Add `BuildDir` parameter to `cxx/run-unit-tests.ps1`

### DIFF
--- a/cxx/run-unit-tests.ps1
+++ b/cxx/run-unit-tests.ps1
@@ -7,13 +7,14 @@ param(
     [string]$Arch = "x64",
     [string]$BuildMethod = "cmake",
     [string]$ExcludeRegex = ".*Performance|Integration|Example.*",
+    [string]$BuildDir = "build",
     [string[]]$CoverageExcludeDirs
 )
 $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $true
 
 $RepoPath = "$PWD/$RepoName"
-$BuildPath = "$RepoPath/$ProjectDir/build"
+$BuildPath = "$RepoPath/$ProjectDir/$BuildDir"
 
 if ($BuildMethod -eq "cmake") {
     Write-Output "Entering '$BuildPath'"


### PR DESCRIPTION
### Changes

- Add `BuildDir` parameter to `cxx/run-unit-tests.ps1` like in [`cxx/build-project.ps1`](https://github.com/51Degrees/common-ci/blob/main/cxx/build-project.ps1#L9)

### Why

- To run CMake/CTest with different env. vars (options) on the same machine.