### PR TITLE
Improve `cxx/run-unit-tests.ps1`

### DIFF
--- a/cxx/run-unit-tests.ps1
+++ b/cxx/run-unit-tests.ps1
@@ -22,8 +22,9 @@ if ($BuildMethod -eq "cmake") {
     try {
         Write-Output "Testing $Name"
 
-        ctest -C $Configuration -T test --no-compress-output --output-on-failure --output-junit "$RepoPath/test-results/unit/$Name.xml" --exclude-regex $ExcludeRegex
-        Write-Output "Results saved to $RepoPath/test-results/unit/$Name.xml"
+        $XmlOutPath = "$RepoPath/test-results/unit/$Name.xml"
+        ctest -C $Configuration -T test --no-compress-output --output-on-failure --output-junit $XmlOutPath --exclude-regex $ExcludeRegex
+        Write-Output "Results saved to $XmlOutPath"
 
         if (Test-Path CMakeFiles/*-cov.dir) {
             Write-Output "Generating coverage report..."
@@ -47,8 +48,9 @@ if ($BuildMethod -eq "cmake") {
         foreach ($TestBinary in $TestBinaries) {
             Write-Output $TestBinary.FullName
             Write-Output "Testing $Name-$($TestBinary.Name)"
-            & $TestBinary.FullName --gtest_catch_exceptions=1 --gtest_break_on_failure=0 --gtest_output=xml:$RepoPath\test-results\unit\$Name_$($TestBinary.BaseName).xml
-            Write-Output "Results saved to $RepoPath\test-results\unit\$Name_$($TestBinary.BaseName).xml"
+            $XmlOutPath = "$RepoPath\test-results\unit\${Name}_$($TestBinary.BaseName).xml"
+            & $TestBinary.FullName --gtest_catch_exceptions=1 --gtest_break_on_failure=0 --gtest_output=xml:$XmlOutPath
+            Write-Output "Results saved to $XmlOutPath"
         }
 
     } finally {

--- a/cxx/run-unit-tests.ps1
+++ b/cxx/run-unit-tests.ps1
@@ -23,6 +23,7 @@ if ($BuildMethod -eq "cmake") {
         Write-Output "Testing $Name"
 
         ctest -C $Configuration -T test --no-compress-output --output-on-failure --output-junit "$RepoPath/test-results/unit/$Name.xml" --exclude-regex $ExcludeRegex
+        Write-Output "Results saved to $RepoPath/test-results/unit/$Name.xml"
 
         if (Test-Path CMakeFiles/*-cov.dir) {
             Write-Output "Generating coverage report..."
@@ -47,6 +48,7 @@ if ($BuildMethod -eq "cmake") {
             Write-Output $TestBinary.FullName
             Write-Output "Testing $Name-$($TestBinary.Name)"
             & $TestBinary.FullName --gtest_catch_exceptions=1 --gtest_break_on_failure=0 --gtest_output=xml:$RepoPath\test-results\unit\$Name_$($TestBinary.BaseName).xml
+            Write-Output "Results saved to $RepoPath\test-results\unit\$Name_$($TestBinary.BaseName).xml"
         }
 
     } finally {


### PR DESCRIPTION
### Changes

- Write file paths for unit test results XMLs.
- Fix path for msbuild
  - underscore in `$Name_$($TestBinary.BaseName).xml` was treated as a part of variable `$Name_`

### Why

- Collision on running multiple test iterations for https://github.com/51Degrees/common-cxx/pull/98

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/0cb35ea9-5fe7-4a48-b110-d77a19190be7) https://github.com/postindustria-tech/common-cxx/actions/runs/14125555345/job/39574105583 | ![image](https://github.com/user-attachments/assets/a99d72a2-e447-43bf-abd5-1b9ffcd1e33c) https://github.com/postindustria-tech/common-cxx/actions/runs/14125943740/job/39575268170 |
