### PR TITLE
GitVersion 6.2 fails with Version 'A.B.C-1' isn't valid

### DIFF
--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -109,7 +109,7 @@ jobs:
             Write-Host "GitVersion already installed."
           } else {
             Write-Host "Installing GitVersion..."
-            dotnet tool install --global GitVersion.Tool --version '6.*'
+            dotnet tool install --global GitVersion.Tool --version '6.1'
           }
 
       - name: Configure

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -106,7 +106,7 @@ jobs:
             Write-Host "GitVersion already installed."
           } else {
             Write-Host "Installing GitVersion..."
-            dotnet tool install --global GitVersion.Tool --version '6.*'
+            dotnet tool install --global GitVersion.Tool --version '6.1'
           }
 
       - name: Configure


### PR DESCRIPTION
Forces the version of gitversion to 6.1 to avoid a bug in 6.2 that prevents a valid version being returned. See the following for examples of the failure.

https://github.com/51Degrees/Pearl.Export/actions/runs/14206211737/job/39804437268#step:5:37
https://github.com/51Degrees/Pearl.Usage/actions/runs/14209137132/job/39812978302#step:5:30

This change can be reversed once the gitversion maintainers have addressed the bug.