### PR TITLE
Use `$Configuration` and `$Arch` in `dotnet/run-unit-tests.ps1`

### DIFF
--- a/dotnet/run-unit-tests.ps1
+++ b/dotnet/run-unit-tests.ps1
@@ -29,7 +29,12 @@ try {
         Get-ChildItem -Path $RepoPath -Recurse -File | ForEach-Object {
             if (($_.DirectoryName -like $DirNameFormatForDotnet -and $_.Name -notlike $skipPattern) -and ($_.Name -match "$Filter")) {
                 Write-Output "Testing Assembly: '$_'"
-                dotnet test $_.FullName --results-directory $TestResultPath --blame-crash --blame-hang-timeout 5m -l "trx" $verbose || $($script:ok = $false)
+                dotnet test $_.FullName `
+                    --no-build `
+                    --configuration $Configuration `
+                    --arch $Arch `
+                    --results-directory $TestResultPath `
+                    --blame-crash --blame-hang-timeout 5m -l "trx" $verbose || $($script:ok = $false)
                 Write-Output "dotnet test LastExitCode=$LASTEXITCODE"
             }
         }
@@ -38,7 +43,10 @@ try {
         Get-ChildItem -Path $RepoPath -Recurse -File | ForEach-Object {
             if (($_.DirectoryName -like $DirNameFormatForNotDotnet -and $_.Name -notlike $skipPattern) -and ($_.Name -match "$Filter")) {
                 Write-Output "Testing Assembly: '$_'"
-                & vstest.console.exe $_.FullName /Logger:trx /ResultsDirectory:$TestResultPath || $($script:ok = $false)
+                & vstest.console.exe $_.FullName `
+                    /Platform:$Arch `
+                    /Logger:trx `
+                    /ResultsDirectory:$TestResultPath || $($script:ok = $false)
                 Write-Output "vstest.console LastExitCode=$LASTEXITCODE"
             }
         }

--- a/dotnet/run-unit-tests.ps1
+++ b/dotnet/run-unit-tests.ps1
@@ -26,13 +26,14 @@ try {
     Write-Output "Testing '$Name'"
     if ($BuildMethod -eq "dotnet"){
         Write-Output "[dotnet] => Looking for '$Filter' in directories like '$DirNameFormatForDotnet'"
+        $PlatformParams = ($Arch -eq "Any CPU") ? @() : @("-p:Platform=$Arch")
         Get-ChildItem -Path $RepoPath -Recurse -File | ForEach-Object {
             if (($_.DirectoryName -like $DirNameFormatForDotnet -and $_.Name -notlike $skipPattern) -and ($_.Name -match "$Filter")) {
                 Write-Output "Testing Assembly: '$_'"
                 dotnet test $_.FullName `
                     --no-build `
                     --configuration $Configuration `
-                    -p:Platform=$Arch `
+                    @PlatformParams `
                     --results-directory $TestResultPath `
                     --blame-crash --blame-hang-timeout 5m -l "trx" $verbose || $($script:ok = $false)
                 Write-Output "dotnet test LastExitCode=$LASTEXITCODE"
@@ -41,10 +42,11 @@ try {
     } else {
         Write-Output "[$BuildMethod] ~> Looking for '$Filter' in directories like '$DirNameFormatForNotDotnet'"
         Get-ChildItem -Path $RepoPath -Recurse -File | ForEach-Object {
+            $PlatformParams = ($Arch -eq "Any CPU") ? @() : @("/Platform:$Arch")
             if (($_.DirectoryName -like $DirNameFormatForNotDotnet -and $_.Name -notlike $skipPattern) -and ($_.Name -match "$Filter")) {
                 Write-Output "Testing Assembly: '$_'"
                 & vstest.console.exe $_.FullName `
-                    /Platform:$Arch `
+                    @PlatformParams `
                     /Logger:trx `
                     /ResultsDirectory:$TestResultPath || $($script:ok = $false)
                 Write-Output "vstest.console LastExitCode=$LASTEXITCODE"

--- a/dotnet/run-unit-tests.ps1
+++ b/dotnet/run-unit-tests.ps1
@@ -32,7 +32,7 @@ try {
                 dotnet test $_.FullName `
                     --no-build `
                     --configuration $Configuration `
-                    --arch $Arch `
+                    -p:Platform=$Arch `
                     --results-directory $TestResultPath `
                     --blame-crash --blame-hang-timeout 5m -l "trx" $verbose || $($script:ok = $false)
                 Write-Output "dotnet test LastExitCode=$LASTEXITCODE"


### PR DESCRIPTION
### Changes

- Use `$Configuration` and `$Arch` in `dotnet/run-unit-tests.ps1`

### Test runs:

- ✅ https://github.com/postindustria-tech/pipeline-dotnet/actions/runs/14267038730
- ✅ https://github.com/51Degrees/ip-intelligence-dotnet-examples/actions/runs/14267511446