### PR TITLE
[.NET] Allow updates of pre-release packages. 

### DIFF
--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -22,8 +22,11 @@ try {
         Write-Output $ProjectFile.FullName
 
         $ProjectPackagesOutdatedRaw = (dotnet list $ProjectFile.FullName package --format json --outdated --highest-patch --include-prerelease)
+        Write-Debug "----- RAW OUTPUT START -----"
+        Write-Debug ($ProjectPackagesOutdatedRaw -Join "`n")
+        Write-Debug "----- RAW OUTPUT END -----"
         if ($ProjectPackagesOutdatedRaw[0][0] -ne '{') {
-            Write-Warning ($ProjectPackagesOutdatedRaw -Join "`n")
+            Write-Warning "^ NOT A VALID JSON -- (continue)"
             continue
         }
 

--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -1,3 +1,4 @@
+[CmdletBinding()]
 param(
     [Parameter(Mandatory=$true)]
     [string]$RepoName,
@@ -20,7 +21,7 @@ try {
         Write-Output "========= ========= ========="
         Write-Output $ProjectFile.FullName
 
-        $ProjectPackagesOutdatedRaw = (dotnet list $ProjectFile.FullName package --format json --outdated --highest-patch)
+        $ProjectPackagesOutdatedRaw = (dotnet list $ProjectFile.FullName package --format json --outdated --highest-patch --include-prerelease)
         if ($ProjectPackagesOutdatedRaw[0][0] -ne '{') {
             Write-Warning ($ProjectPackagesOutdatedRaw -Join "`n")
             continue


### PR DESCRIPTION
### Changes

- Add `--include-prerelease` switch to `dotnet list package --outdated` call.
- Always write (in debug) raw output (before attempting to analyze).

### Why

Fixes
```txt
WARNING: error: Sequence contains no matching element
```
^ https://github.com/51Degrees/ip-intelligence-dotnet-examples/actions/runs/14268277344/job/39995309575#step:4:50

### Runs

- ✅ https://github.com/51Degrees/ip-intelligence-dotnet-examples/actions/runs/14268574118/job/39996266424