### PR TITLE
[.NET] Add switch to allow updates of pre-release packages.

### DIFF
--- a/dotnet/run-update-dependencies-github.ps1
+++ b/dotnet/run-update-dependencies-github.ps1
@@ -26,7 +26,7 @@ $FetchVersions = {
     }
 }
 
-$IncludePrereleaseParams = $IncludePrerelease ? @() : @("-IncludePrerelease")
+$IncludePrereleaseParams = $IncludePrerelease ? @("-IncludePrerelease") : @()
 ./dotnet/run-update-dependencies.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name -Filter $Filter -FetchVersions $FetchVersions @IncludePrereleaseParams
 
 exit $LASTEXITCODE

--- a/dotnet/run-update-dependencies-github.ps1
+++ b/dotnet/run-update-dependencies-github.ps1
@@ -5,7 +5,8 @@ param(
     [string]$OrgName,
     [string]$ProjectDir = ".",
     [string]$Filter = "*.csproj",
-    [string]$Name
+    [string]$Name,
+    [switch]$IncludePrerelease
 )
 
 $FetchVersions = {
@@ -25,6 +26,7 @@ $FetchVersions = {
     }
 }
 
-./dotnet/run-update-dependencies.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name -Filter $Filter -FetchVersions $FetchVersions
+$IncludePrereleaseParams = $IncludePrerelease ? @() : @("-IncludePrerelease")
+./dotnet/run-update-dependencies.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name -Filter $Filter -FetchVersions $FetchVersions @IncludePrereleaseParams
 
 exit $LASTEXITCODE

--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -9,7 +9,7 @@ param(
 )
 
 Write-Output "IncludePrerelease = $IncludePrerelease"
-$IncludePrereleaseParams = $IncludePrerelease ? @() : @("--include-prerelease")
+$IncludePrereleaseParams = $IncludePrerelease ? @("--include-prerelease") : @()
 
 
 $RepoPath = [IO.Path]::Combine($pwd, $RepoName)

--- a/dotnet/run-update-dependencies.ps1
+++ b/dotnet/run-update-dependencies.ps1
@@ -8,7 +8,7 @@ param(
     [scriptblock]$FetchVersions = { param($PackageName) Find-Package -Name $PackageName -AllVersions -Source https://api.nuget.org/v3/index.json -ErrorAction SilentlyContinue }
 )
 
-Write-Debug "IncludePrerelease = $IncludePrerelease"
+Write-Output "IncludePrerelease = $IncludePrerelease"
 $IncludePrereleaseParams = $IncludePrerelease ? @() : @("--include-prerelease")
 
 


### PR DESCRIPTION
### Changes

- Add `IncludePrerelease` switch to `dotnet/run-update-dependencies` scripts.
  - Adds `--include-prerelease` switch to `dotnet list package --outdated` call.
- Log all non-zero exit codes (of `dotnet` calls`) as warnings.
- Return last non-zero exit code (of `dotnet` calls) as final exit code.
- Write out semi-consolidated lists of (some) failed operations before exiting the script.

### Why

Fixes
```txt
WARNING: error: Sequence contains no matching element
```
^ https://github.com/51Degrees/ip-intelligence-dotnet-examples/actions/runs/14268277344/job/39995309575#step:4:50

### Runs

- ✅ (switch OFF) https://github.com/51Degrees/ip-intelligence-dotnet-examples/actions/runs/14306607459
  - `Sequence contains no matching element` reproduced with additional logs.
  - Script's exit code (1) NOT handled
- 🔺 (switch OFF) https://github.com/51Degrees/ip-intelligence-dotnet-examples/actions/runs/14306877322
  - `Sequence contains no matching element` reproduced with additional logs.
  - Script's exit code (1) handled externally -- by [update-packages.ps1](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/ci/update-packages.ps1#L24)
- ✅ (switch ON) https://github.com/51Degrees/ip-intelligence-dotnet-examples/actions/runs/14268574118/job/39996266424
  - No error

### Related

- https://github.com/51Degrees/common-ci/pull/161 -- to be superceded by _this_ PR