### PR TITLE
cxx: package the whole build directory during Nightly Publish

### DIFF
--- a/cxx/build-package.ps1
+++ b/cxx/build-package.ps1
@@ -22,4 +22,4 @@ try {
 }
 
 Write-Output "Copying build to '$OutPath'"
-Copy-Item -Recurse -Path $BuildPath/bin -Destination $OutPath
+Copy-Item -Recurse -Path $BuildPath -Destination $OutPath


### PR DESCRIPTION
Package the whole `build` directory for cxx in order to run performance tests as part of Nightly Publish and then do ComparePerformance step as part of it.  The `build` directory contains cmake artifacts necessary for ctest