### PR TITLE
documentation: allow using other branches

### DIFF
--- a/.github/workflows/nightly-documentation-update.yml
+++ b/.github/workflows/nightly-documentation-update.yml
@@ -10,6 +10,9 @@ on:
         required: false
         type: string
         default: 51degrees
+      branch:
+        type: string
+        default: main
       user:
         required: false
         type: string
@@ -56,6 +59,7 @@ jobs:
           -GitHubToken ${{ secrets.token }} `
           -RepoName ${{ inputs.repo-name }} `
           -OrgName ${{ inputs.org-name }} `
+          -Branch '${{ inputs.branch }}' `
           -GitHubUser ${{ inputs.user }} `
           -GitHubEmail ${{ inputs.email }} `
           -DryRun $DryRun `

--- a/nightly-documentation-update.ps1
+++ b/nightly-documentation-update.ps1
@@ -3,6 +3,7 @@ param (
     [string]$RepoName,
     [Parameter(Mandatory=$true)]
     [string]$OrgName,
+    [string]$Branch = "main",
     [string]$GitHubUser,
     [string]$GitHubEmail,
     [string]$GitHubToken,
@@ -14,6 +15,7 @@ $ErrorActionPreference = "Stop"
 ./generate-documentation.ps1 `
     -RepoName $RepoName `
     -OrgName $OrgName `
+    -Branch $Branch, `
     -GitHubUser $GitHubUser `
     -GitHubEmail $GitHubEmail `
     -GitHubToken $GitHubToken `
@@ -32,7 +34,7 @@ Write-Output "::endgroup::"
 
 if ($LASTEXITCODE -eq 0) {
     Write-Output "::group::Commit Changes"
-    ./steps/commit-changes.ps1 -RepoName $RepoName -Message "Update documentation"
+    ./steps/commit-changes.ps1 -RepoName $RepoName -Message "Update documentation from $Branch"
     Write-Output "::endgroup::"
 
     Write-Output "::group::Push Changes"


### PR DESCRIPTION
The workflow still has to run from main to make simultaneous runs harder to happen accidentally. The intended way to use this is to run the workflow multiple times from main, serially, and pass the branch as a parameter if needed. This is to avoid attempting to push to gh-pages from multiple jobs simultaneously.

Required for: https://github.com/51Degrees/documentation/pull/47