### PR TITLE
compare performance: continue on error

### DIFF
--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -325,6 +325,7 @@ jobs:
           merge-multiple: true
 
       - name: Compare Performance
+        continue-on-error: true
         run: |
           ./nightly-publish.compare-performance.ps1 `
           -RepoName '${{ inputs.repo-name }}' `

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -322,6 +322,7 @@ jobs:
           merge-multiple: true
 
       - name: Compare Performance
+        continue-on-error: true
         run: |
           ./nightly-publish.compare-performance.ps1 `
           -RepoName '${{ inputs.repo-name }}' `

--- a/.github/workflows/nightly-pull-request.yml
+++ b/.github/workflows/nightly-pull-request.yml
@@ -215,6 +215,7 @@ jobs:
           merge-multiple: true
 
       - name: Compare Performance
+        continue-on-error: true
         run: |
           $DryRun = [bool]::Parse( "${{ inputs.dryrun }}" )
           $Options = $(ConvertFrom-Json -AsHashtable '${{ needs.configure.outputs.options }}')


### PR DESCRIPTION
Compare Performance is very unstanble due to GitHub Runner's performance fluctuations. Ignore it until we find a workaround.