### PR TITLE
Expose `ToolsBranch`/`tools-branch` on `nightly-data-file-change`

### DIFF
--- a/.github/workflows/nightly-data-file-change.yml
+++ b/.github/workflows/nightly-data-file-change.yml
@@ -37,6 +37,9 @@ on:
       metadata-branch:
         type: string
         default: 'main'
+      tools-branch:
+        type: string
+        default: 'main'
       common-ci-ref:
         type: string
         default: ''
@@ -81,4 +84,5 @@ jobs:
           -Product ${{ inputs.data-product }} `
           -FileName ${{ inputs.data-filename }} `
           -MetadataBranch ${{ inputs.metadata-branch }} `
+          -ToolsBranch ${{ inputs.tools-branch }} `
           -DryRun $DryRun

--- a/nightly-data-file-change.ps1
+++ b/nightly-data-file-change.ps1
@@ -13,6 +13,7 @@ param (
     [string]$FileName = "TAC-HashV41.hash.gz",
     [string]$GitHubToken,
     [string]$MetadataBranch = "main",
+    [string]$ToolsBranch = "main",
     [bool]$DryRun = $False
 )
 $ErrorActionPreference = "Stop"
@@ -29,7 +30,7 @@ Write-Output "::group::Clone $RepoName - $Branch"
 Write-Output "::endgroup::"
 
 Write-Output "::group::Clone Tools"
-./steps/clone-repo.ps1 -RepoName "tools" -OrgName $OrgName
+./steps/clone-repo.ps1 -RepoName "tools" -OrgName $OrgName -Branch $ToolsBranch
 Write-Output "::endgroup::"
 
 Write-Output "::group::Fetch Assets"


### PR DESCRIPTION
### Changes

- Expose `ToolsBranch`/`tools-branch` on `nightly-data-file-change` (`.ps1`/`.yml`).

### Related

- Used with
  - https://github.com/51Degrees/ip-intelligence-dotnet/pull/239
- to check
  - https://github.com/51Degrees/tools/pull/27
    - 🛠️ https://github.com/51Degrees/ip-intelligence-dotnet/actions/runs/23431700550
    - ➡️ https://github.com/51Degrees/ip-intelligence-dotnet/commit/f4fa3d63d273f0ac1931e99f1df60a4d9377cad5