### PR TITLE
add dashboard triage agent

### DIFF
--- a/.github/workflows/dashboard-triage.yml
+++ b/.github/workflows/dashboard-triage.yml
@@ -17,5 +17,6 @@ jobs:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
         run: python scripts/dashboard-triage/triage.py
       - run: cat scripts/dashboard-triage/out/*.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dashboard-triage.yml
+++ b/.github/workflows/dashboard-triage.yml
@@ -1,7 +1,6 @@
 name: Dashboard Triage
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: '0 7 * * *'

--- a/.github/workflows/dashboard-triage.yml
+++ b/.github/workflows/dashboard-triage.yml
@@ -1,0 +1,21 @@
+name: Dashboard Triage
+
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * *'
+
+jobs:
+  dashboard-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -fsSL https://claude.ai/install.sh | bash
+      - run: claude --version
+      - uses: actions/checkout@v6
+      - env:
+          GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+        run: python scripts/dashboard-triage/triage.py
+      - run: cat scripts/dashboard-triage/out/*.md >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/dashboard-triage/.gitignore
+++ b/scripts/dashboard-triage/.gitignore
@@ -1,0 +1,6 @@
+out/
+__pycache__/
+*.pyc
+# Personal launcher — environment-specific (keychain resolvers,
+# pyenv pins, CI bootstrap, etc.). Each runner provides its own.
+launch_triage.sh

--- a/scripts/dashboard-triage/README.md
+++ b/scripts/dashboard-triage/README.md
@@ -12,10 +12,15 @@ See [`SPEC.md`](SPEC.md) for the full design.
 - Python 3.10+
 - `gh` CLI on `PATH`
 - `claude` CLI on `PATH`, authenticated by **one** of:
-  - `ANTHROPIC_API_KEY` in the env (recommended for CI / remote
-    runners — no interactive login possible there), or
+  - `ANTHROPIC_API_KEY` (direct Anthropic API), or
+  - `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` (LiteLLM / proxy), or
   - A valid Claude Code session on the machine (`claude /login` once
-    locally — fine for a workstation).
+    locally — fine for a workstation, not for CI).
+- If your proxy doesn't expose Claude Code's default model (e.g.
+  `claude-opus-4-7[1m]`), set `ANTHROPIC_MODEL` to a model the proxy
+  does expose (e.g. `claude-sonnet-4-6`). The script will pass it as
+  `claude -p --model "$ANTHROPIC_MODEL"`. Without it, claude uses
+  whichever model is default in your CLI build.
 - A GitHub token in the `GH_TOKEN` env var, scoped to 51Degrees with at
   least:
   - `actions:read`

--- a/scripts/dashboard-triage/README.md
+++ b/scripts/dashboard-triage/README.md
@@ -76,6 +76,28 @@ not overwrite an earlier report. The `out/` directory is gitignored.
 Progress lines on stderr are timestamped (`[HH:MM:SS +elapsed]`) so you
 can read off per-step duration by subtracting between consecutive lines.
 
+## Scheduled run (GitHub Actions)
+
+Scheduled and triggered by
+[`.github/workflows/dashboard-triage.yml`](../../.github/workflows/dashboard-triage.yml)
+— see that file for cadence and triggers. The report is appended to
+the run's `$GITHUB_STEP_SUMMARY`.
+
+Required repository secrets:
+
+| Secret | Purpose |
+| ------ | ------- |
+| `ACCESS_TOKEN` | `GH_TOKEN` for the run — needs `actions:read` + `actions:write` |
+| `ANTHROPIC_*` | Whatever env vars the `claude` CLI needs to authenticate (see "Requirements" above). In our setup that's `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_MODEL` for the LiteLLM proxy; a direct-Anthropic setup would use `ANTHROPIC_API_KEY` instead. |
+
+**Two-hop env contract.** Each var the `claude` CLI needs has to be wired
+through twice: (1) listed in the workflow YAML's `env:` block so it reaches
+the Python script, and (2) the script then forwards its full environment
+to the `claude -p` subprocess verbatim — stripping only `GH_TOKEN` and
+`GITHUB_TOKEN` (see `claude_env()` in `triage.py`). So to add a new
+`ANTHROPIC_*` var, just add it as a secret, mention it in the workflow
+YAML's `env:` block, and it'll automatically reach claude.
+
 ## What it does (and deliberately does not do)
 
 ### Does

--- a/scripts/dashboard-triage/README.md
+++ b/scripts/dashboard-triage/README.md
@@ -1,0 +1,123 @@
+# Dashboard Triage
+
+Agentic pipeline that scans every workflow listed in
+[`DASHBOARD.md`](../../DASHBOARD.md), finds the failed ones, asks Claude to
+analyse each failure, retries flaky-looking ones once, and writes a single
+markdown report.
+
+See [`SPEC.md`](SPEC.md) for the full design.
+
+## Requirements
+
+- Python 3.10+
+- `gh` CLI on `PATH`
+- `claude` CLI on `PATH`, authenticated by **one** of:
+  - `ANTHROPIC_API_KEY` in the env (recommended for CI / remote
+    runners — no interactive login possible there), or
+  - A valid Claude Code session on the machine (`claude /login` once
+    locally — fine for a workstation).
+- A GitHub token in the `GH_TOKEN` env var, scoped to 51Degrees with at
+  least:
+  - `actions:read`
+  - `contents:read`
+  - `actions:write` — needed only by `gh run rerun`
+
+The token is **never** passed to Claude (see [`SPEC.md`](SPEC.md), "Auth"),
+so a leak surface is the parent script + your shell history only.
+
+## Running
+
+The script reads `GH_TOKEN` (and `ANTHROPIC_API_KEY`, if you're using
+that to authenticate Claude) from the environment. Anything that puts
+valid values there works:
+
+```bash
+GH_TOKEN=ghp_xxx ANTHROPIC_API_KEY=sk-ant-xxx \
+    python3 scripts/dashboard-triage/triage.py
+```
+
+(Omit `ANTHROPIC_API_KEY` if the `claude` CLI is already logged in via
+`claude /login` on that machine.)
+
+You will likely want to wrap that in a local launcher that resolves the
+token from whatever secret store your machine uses (macOS Keychain,
+1Password CLI, `pass`, CI secret, etc.). Such launchers are
+**environment-specific and not committed** — `launch_triage.sh` is in
+`.gitignore`. Drop your own copy beside the Python script if you want a
+one-command invocation.
+
+Sketch of a local launcher (do not check in):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+export GH_TOKEN=$(<command that prints the token>)
+exec python3 triage.py "$@"
+```
+
+Total runtime is dominated by the rerun-poll phase — up to ~90 minutes
+per flagged job, although reruns execute in parallel on GitHub.
+
+The report is written to:
+
+```
+scripts/dashboard-triage/out/report-YYYY-MM-DD-HHMM.md
+```
+
+Each invocation gets its own timestamped file — re-running mid-day will
+not overwrite an earlier report. The `out/` directory is gitignored.
+
+Progress lines on stderr are timestamped (`[HH:MM:SS +elapsed]`) so you
+can read off per-step duration by subtracting between consecutive lines.
+
+## What it does (and deliberately does not do)
+
+### Does
+
+- Read `DASHBOARD.md` locally
+- Read public GitHub Actions API data to find failed runs
+- Download each failed run's logs zip via the API and extract to a
+  tempdir
+- Invoke `claude -p` per failure to produce a one-paragraph analysis
+- Trigger ONE `gh run rerun` per Claude-flagged-flaky job
+- Poll until reruns finish, then run a second-pass analysis on the ones
+  that still failed
+- Write a markdown report
+
+### Does NOT
+
+- Post any comments, reviews, issues, or labels to GitHub
+- Commit or push anything
+- Rerun any job more than once per invocation
+- Send `GH_TOKEN` to Anthropic — `GH_TOKEN` and `GITHUB_TOKEN` are
+  stripped from the environment before each `claude -p` call
+  (`ANTHROPIC_API_KEY`, if set, is passed through unchanged because
+  `claude` itself needs it to authenticate to the Anthropic API)
+- Send full failure logs to Anthropic in bulk — Claude only reads the
+  slices it needs via `ls`/`grep`/`head`/`tail` on the local tempdir
+
+## Files
+
+| File | Purpose | Committed |
+| ---- | ------- | --------- |
+| `SPEC.md` | Design spec | yes |
+| `README.md` | This file | yes |
+| `triage.py` | Single-file pipeline | yes |
+| `prompts.py` | First-pass and second-pass prompt templates | yes |
+| `.gitignore` | Hides `out/`, `__pycache__/`, and `launch_triage.sh` | yes |
+| `launch_triage.sh` | Per-machine launcher (token resolver, Python pin) | **no — gitignored** |
+| `out/report-*.md` | Generated reports | no |
+
+## Tuning
+
+Constants live at the top of `triage.py`:
+
+- `POLL_INTERVAL_S` (default 60) — rerun poll interval
+- `POLL_TIMEOUT_S` (default 5400) — max wait per rerun
+- `CLAUDE_WORKERS` (default 5) — concurrent `claude -p` calls
+- `CLAUDE_TIMEOUT_S` (default 600) — per-call cap
+- `FAILED_CONCLUSIONS` — which run conclusions count as "failed"
+
+Prompt wording lives in `prompts.py`. Edit that file to retune analysis
+behaviour without touching the pipeline code.

--- a/scripts/dashboard-triage/SPEC.md
+++ b/scripts/dashboard-triage/SPEC.md
@@ -1,0 +1,335 @@
+# Dashboard Triage — Design Spec
+
+## Goal
+
+Given the CI dashboard in [`DASHBOARD.md`](../../DASHBOARD.md), find every monitored workflow whose latest run on its tracked branch is in a terminal failure state, get Claude to analyse each one, retry the ones Claude believes are flaky once, and emit a single markdown report.
+
+KISS, DRY. No GitHub writes other than the explicitly-allowed `gh run rerun`.
+
+## Layout
+
+```
+scripts/dashboard-triage/
+├── SPEC.md            (this file — committed)
+├── README.md          (how to run — committed)
+├── triage.py          (single-file pipeline — committed)
+├── prompts.py         (first- and second-attempt prompt templates — committed)
+├── .gitignore         (committed)
+├── launch_triage.sh   (per-machine launcher — GITIGNORED, not committed)
+└── out/               (gitignored)
+    └── report-YYYY-MM-DD-HHMM.md
+```
+
+### Per-machine launcher (`launch_triage.sh`, gitignored)
+
+Each runner provides its own thin launcher whose only job is to put a valid `GH_TOKEN` into the environment (and, on CI/remote runners, `ANTHROPIC_API_KEY` too) before invoking `python3 triage.py`. Concrete examples — macOS Keychain, 1Password CLI, `pass`, a GitHub Actions secret — are environment-specific and intentionally out of scope for the committed code.
+
+Sketch:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+export GH_TOKEN=$(<command that prints a 51Degrees token>)
+exec python3 triage.py "$@"
+```
+
+`triage.py` reads `GH_TOKEN` from `os.environ` and exits cleanly if it's missing. The Python never touches secret stores directly — single responsibility per layer.
+
+## Pipeline
+
+```
+parse_dashboard → probe_runs → fetch_logs → first_pass_analyse
+  → rerun_flaky → poll_reruns → fetch_rerun_logs → second_pass_analyse
+  → write_report
+```
+
+Each step is its own function in `triage.py`. The single `JobResult` dataclass flows through them, accreting fields.
+
+All log files live under a single `tempfile.TemporaryDirectory()` created at the top of `main()`; the dir is wiped on exit (success or exception).
+
+### 1. `parse_dashboard()`
+
+- Reads the local `DASHBOARD.md` (path = `../../DASHBOARD.md` relative to the script).
+- Walks each markdown table row. For each row, extracts:
+  - `category` (last `###` heading seen)
+  - `repo` (the first `[name](https://github.com/51Degrees/name)` link)
+  - `branch` (the back-ticked value in the second cell, typically `main`)
+  - `workflows` — every `actions/workflows/<file>.yml/badge.svg` URL in the status cell, deduplicated.
+- One row can yield multiple `(repo, branch, workflow)` tuples.
+
+### 2. `probe_runs(jobs)`
+
+- For each tuple, calls `gh api repos/51Degrees/{repo}/actions/workflows/{wf}/runs?branch={br}&per_page=1`.
+- Captures from the response: `id`, `status`, `conclusion`, `html_url`, `head_sha`, `head_commit.message`, `actor.login` (or `triggering_actor.login`), `run_started_at` (or `created_at`). All of these flow into the `JobResult` and are used to render the prompt — Claude gets the full picture without having to call GitHub itself.
+- Keeps only runs where `status == "completed"` AND `conclusion` is in
+  `{"failure", "cancelled", "timed_out", "startup_failure"}`.
+- In-progress runs are skipped (no point analysing a build still running).
+- API failures for a single workflow log a warning and skip — don't abort the whole pipeline.
+
+### 3. `fetch_logs(failures, tmp_dir)`
+
+- For every failed `JobResult`, the parent script (using `GH_TOKEN`) downloads the run's logs as a zip via:
+  ```
+  gh api repos/51Degrees/{repo}/actions/runs/{run_id}/logs > <log_dir>/_logs.zip
+  ```
+  …then extracts it with Python's `zipfile` module into a per-run directory under `tmp_dir` and deletes the zip. (`gh run view --log` / `--log-failed` is unreliable in some `gh` versions — direct API + extract sidesteps that.)
+- Records the directory path on `job.log_path`. Inside it: one `.txt` per matrix job, plus per-step subfolders.
+- If the download fails or the zip is empty/corrupt, set `log_path = None` and let Claude work from the run URL alone.
+- The logs live on local disk, never sent to Anthropic in bulk — Claude only reads slices via Bash (`ls`, `grep -r`, `head`, `tail`).
+
+### 4. `first_pass_analyse(failures)`
+
+- ThreadPoolExecutor with 5 workers — Claude calls are slow but independent.
+- For each `JobResult`, runs `claude -p --allowed-tools "Bash WebFetch"` and pipes the formatted `FIRST_PROMPT` via **stdin** (NOT via argv — `--allowed-tools` is a variadic flag and would otherwise consume the positional prompt as additional tool names).
+- **No `GH_TOKEN` in the subprocess env.** Claude inherits a sanitised env (`os.environ.copy()` then `pop("GH_TOKEN", None)` and `pop("GITHUB_TOKEN", None)`). `ANTHROPIC_API_KEY` is left in place since `claude` itself needs it to authenticate to the Anthropic API on machines without an interactive Claude Code session.
+- `FIRST_PROMPT` contains: run URL, conclusion, repo, workflow file, attempt number = 1, **and the absolute path to the log directory**. Tells Claude:
+  - Start with `ls` of the log directory, then `grep`/`head`/`tail` slices. Don't `cat` whole files.
+  - Browse public source via `WebFetch` against `raw.githubusercontent.com` if needed.
+  - You do not have `gh` auth — do not attempt authenticated API calls.
+  - Produce one short paragraph + relevant file links (full GitHub URLs with line numbers when applicable).
+  - If you believe the failure is test flakiness rather than a real bug, end your output with the single token `RERUN` on its own line.
+- Parser: if the last non-empty line of stdout, stripped, equals `RERUN`, set `job.flagged_rerun = True` and strip that line from the stored analysis.
+- Store the analysis text on `job.first_analysis`.
+
+### 5. `rerun_flaky(jobs)`
+
+- For every `job` with `flagged_rerun == True`:
+  - `gh run rerun {run_id} --repo 51Degrees/{repo}` (this is the explicit exception to the no-writes rule).
+  - `gh run rerun` re-runs the same run id with an incremented attempt number — there is no new run id to look up.
+
+### 6. `poll_reruns(jobs)`
+
+- For every job that was rerun, poll `gh run view {run_id} --repo 51Degrees/{repo} --json status,conclusion,url` every 60 seconds.
+- Terminal when `status == "completed"`. Capture `conclusion` as `job.rerun_conclusion` and `url` as `job.rerun_run_url` (it points at the latest attempt).
+- Per-job cap: 90 minutes. If exceeded, set `rerun_conclusion = "timed_out_polling"` and move on.
+
+### 7. `fetch_rerun_logs(jobs, tmp_dir)`
+
+- For every rerun that ended in failure, download its log zip the same way as step 3 to a `<dir>-rerun/` directory under `tmp_dir`.
+- Records the directory path on `job.rerun_log_path`.
+
+### 8. `second_pass_analyse(jobs)`
+
+- For every job whose rerun did not succeed (`rerun_conclusion != "success"`), invoke Claude again with `SECOND_PROMPT` (attempt = 2, no `RERUN` option mentioned). The prompt references `job.rerun_log_path` so Claude looks at the latest-attempt logs, not the original ones.
+- Same tool scope, same env sanitisation, same stdin-piped invocation, same threading.
+- Store result on `job.second_analysis`.
+
+### 9. `write_report(jobs)`
+
+- Writes `out/report-YYYY-MM-DD-HHMM.md` (timestamped per invocation — running twice in one day produces two separate files; no overwrite).
+- Three sections:
+  - **Passed after rerun** — repo, workflow, original run URL, rerun URL. No analysis text needed.
+  - **Failed after rerun** — repo, workflow, both run URLs, `second_analysis` text.
+  - **Failed, not flagged as flaky** — first-pass failures Claude did not flag for rerun; show `first_analysis`.
+- Top of report: timestamp, total monitored, total failed, breakdown.
+
+## Data model
+
+```python
+@dataclass
+class JobResult:
+    category: str
+    repo: str
+    branch: str
+    workflow: str
+    run_id: int
+    conclusion: str
+    run_url: str
+    head_sha: str
+    head_commit_message: str
+    triggered_by: str
+    started_at: str
+
+    log_path: str | None = None           # directory of extracted .txt files
+    first_analysis: str | None = None
+    flagged_rerun: bool = False
+
+    rerun_triggered: bool = False
+    rerun_conclusion: str | None = None
+    rerun_run_url: str | None = None      # latest-attempt URL after rerun
+    rerun_log_path: str | None = None     # directory, same shape as log_path
+
+    second_analysis: str | None = None
+```
+
+## Auth
+
+Two independent secrets are needed:
+
+1. **`GH_TOKEN`** — a GitHub PAT scoped to 51Degrees with `actions:read`, `contents:read`, `actions:write` (the last only for `gh run rerun`). Supplied via env var by whatever launcher the runner uses (`launch_triage.sh`, a CI secret, a shell wrapper, etc.). Used only by the parent script for `gh` calls.
+
+2. **Claude CLI authentication** — either:
+   - `ANTHROPIC_API_KEY` in the env (CI/remote runners), or
+   - An interactive Claude Code session (`claude /login` once, fine for a workstation).
+
+Before launching `claude -p`, the script does:
+
+```python
+claude_env = os.environ.copy()
+claude_env.pop("GH_TOKEN", None)
+claude_env.pop("GITHUB_TOKEN", None)
+```
+
+This way `GH_TOKEN` cannot end up in Claude's stdout (and therefore not in the report file), and cannot end up in Anthropic-side conversation transcripts even if Claude tries to read it. `ANTHROPIC_API_KEY` is intentionally **not** stripped — it's the Anthropic API client's own credential.
+
+If `GH_TOKEN` is missing the script exits with a clear error. Claude's auth is checked implicitly: the first `claude -p` invocation either succeeds or returns an error that surfaces in the report as `[claude error: ...]`.
+
+Claude works from:
+1. The pre-downloaded log directory on local disk (parent-fetched with `GH_TOKEN`, then Claude reads slices via `ls`/`grep`/`head`/`tail` — never `cat` whole files).
+2. `WebFetch` against `raw.githubusercontent.com` for public 51Degrees source files.
+
+The prompt explicitly tells Claude it has no GitHub auth, so attempts at authenticated API calls fail fast rather than degrade silently.
+
+### Note on `claude -p` semantics
+
+`claude -p` is non-interactive only in the sense that there's no stdin TTY for chat — within a single invocation Claude still runs a full tool-use loop, making many `Bash` / `WebFetch` calls (subject to `--allowed-tools`) before producing its final assistant message, which is what arrives on stdout. So a single `claude -p` call per failure is enough for Claude to grep the logs, fetch source files, reason, and respond.
+
+Implementation detail: the prompt is fed to `claude` via stdin (`subprocess.run(..., input=prompt, ...)`). `--allowed-tools` is a variadic argparse flag — passing the prompt as a positional argv would have it consumed as another tool name and trigger `Error: Input must be provided either through stdin or as a prompt argument`.
+
+## Prompts (`prompts.py`)
+
+Two Python f-string templates, exported as module-level constants. Each is rendered with `template.format(**fields)` where `fields` are pulled off the `JobResult`. Keeping them in their own module makes prompt iteration cheap — no `triage.py` edits to retune wording.
+
+### Common context fields (collected by `probe_runs`)
+
+```
+repo, branch, workflow, run_url, conclusion,
+head_sha, head_commit_message, triggered_by,
+started_at, log_path
+```
+
+(For the second pass we additionally pass `rerun_run_url`, `rerun_conclusion`, `rerun_log_path`.)
+
+### `FIRST_PROMPT` (attempt 1, may emit `RERUN`)
+
+```
+You are triaging a failed CI workflow run for the 51Degrees engineering team.
+This is ATTEMPT 1 of analysis.
+
+Run context
+-----------
+Repository:        51Degrees/{repo}
+Branch:            {branch}
+Workflow file:     {workflow}
+Run URL:           {run_url}
+Conclusion:        {conclusion}
+Head commit:       {head_sha}
+Commit message:    {head_commit_message}
+Triggered by:      {triggered_by}
+Started at:        {started_at}
+
+The run's logs have been extracted locally to this directory (one .txt
+file per workflow job, possibly inside per-step subfolders):
+  {log_path}
+
+Your environment
+----------------
+- You have NO GitHub authentication. Do not attempt authenticated API calls
+  (no `gh` auth, no GitHub API tokens). Public-only access is fine.
+- Start by listing the log dir: `ls {log_path}` (and `find {log_path} -name '*.txt'`).
+  The names tell you which matrix job/step each file belongs to.
+- Inspect logs with Bash: prefer `grep -ri "error\|fail\|exception" {log_path}`,
+  `tail -200`, `head -200`, `awk`/`sed` slices. Do NOT `cat` whole files -
+  they may be large.
+- Use WebFetch against raw.githubusercontent.com to read public source
+  files in 51Degrees repos when relevant.
+
+Your task
+---------
+1. Identify the immediate cause of failure from the logs.
+2. Decide whether this looks like a FLAKY failure (transient infra issue,
+   network hiccup, race condition, timeout with no real cause, runner
+   shortage, package mirror outage) or a REAL failure (test regression,
+   broken build, missing dependency, code bug, configuration error).
+3. Produce a SINGLE concise paragraph (3-5 sentences) describing the cause
+   and a remedy. Where relevant, link to specific source files using full
+   GitHub URLs with line numbers, e.g.
+     https://github.com/51Degrees/{repo}/blob/{head_sha}/path/to/file.cs#L42
+
+Output format
+-------------
+- Your paragraph, then a blank line.
+- If AND ONLY IF you believe this is flakiness that a single rerun is
+  likely to clear, end your output with one final line containing nothing
+  but the token:
+      RERUN
+- If the failure is real, OMIT the RERUN token entirely.
+
+Be terse. No preamble, no apologies, no "I would recommend".
+```
+
+### `SECOND_PROMPT` (attempt 2, post-rerun, no `RERUN` allowed)
+
+```
+You are triaging a failed CI workflow run for the 51Degrees engineering team.
+This is ATTEMPT 2 - the workflow has ALREADY been rerun once and still
+failed. Do NOT suggest another rerun; this is not flakiness.
+
+Run context
+-----------
+Repository:            51Degrees/{repo}
+Branch:                {branch}
+Workflow file:         {workflow}
+Original run URL:      {run_url}     (conclusion: {conclusion})
+Rerun URL (attempt 2): {rerun_run_url}  (conclusion: {rerun_conclusion})
+Head commit:           {head_sha}
+Commit message:        {head_commit_message}
+Triggered by:          {triggered_by}
+
+The rerun's logs have been extracted locally to this directory (one .txt
+file per workflow job, possibly inside per-step subfolders):
+  {rerun_log_path}
+
+Your environment
+----------------
+- You have NO GitHub authentication. Public-only access.
+- Start with `ls {rerun_log_path}` to see the log files.
+- Inspect logs with Bash slices (`grep -ri`, `tail`, `head`). Do NOT `cat`
+  whole files.
+- Use WebFetch against raw.githubusercontent.com for public source files.
+
+Your task
+---------
+Produce a SINGLE concise paragraph (3-5 sentences) covering:
+- The most likely ROOT CAUSE (not just the surface symptom).
+- A concrete, ACTIONABLE FIX - name files, functions, or config keys.
+  Include full GitHub source URLs with line numbers where they help, e.g.
+     https://github.com/51Degrees/{repo}/blob/{head_sha}/path#Lnn
+
+Be terse and specific. No preamble, no apologies, no "I would recommend",
+no suggestions to rerun.
+```
+
+The canonical strings live in `prompts.py`; the spec versions above mirror them for review.
+
+## DRY helpers
+
+Only two helpers, both in `triage.py` (no separate utils file — overkill):
+
+- `gh_json(args: list[str]) -> dict | list` — wraps `subprocess.run(["gh", ...])`, parses stdout as JSON, returns. Used everywhere `gh` is called for structured output.
+- `claude_analyse(prompt: str) -> str` — runs `claude -p --allowed-tools "Bash WebFetch"` with the prompt piped via stdin, captures stdout. Used by both first and second pass.
+
+Plus a tiny `log(msg)` that prefixes each stderr line with `[HH:MM:SS +elapsed]` so you can read off per-step duration by subtracting between consecutive lines.
+
+No other abstractions.
+
+## Tool scope for Claude
+
+`--allowed-tools "Bash WebFetch"`. Bash gives Claude `gh` (without auth), `cat`, `grep`, etc. WebFetch lets it pull raw source from `raw.githubusercontent.com`. No `Write`/`Edit` — Claude cannot modify files during analysis.
+
+## What this deliberately does NOT do
+
+- No PR comments, reviews, issue creation, label edits, commits, pushes.
+- No retry beyond the one explicit rerun per flagged job per invocation.
+- No persistent state between runs — each invocation is a fresh report.
+- No notification/email — just writes the `.md`. Open it manually.
+- No double-run protection: running the script back-to-back will see any new failures (including reruns from the previous invocation that subsequently failed) and could trigger fresh reruns. Operator's responsibility to keep cadence sane (typically: once per day after the nightly pipeline finishes).
+
+## Operational notes
+
+- Invocation: `./launch_triage.sh` (personal launcher) or directly `GH_TOKEN=... [ANTHROPIC_API_KEY=...] python3 scripts/dashboard-triage/triage.py`.
+- Total runtime dominated by the rerun-poll phase (up to ~90 min per rerun, but reruns run in parallel on GitHub).
+- Idempotent for the parse/probe/analyse phases; not for the rerun phase (see above).
+- Output: `out/report-YYYY-MM-DD-HHMM.md`, one file per invocation, gitignored.
+- Progress lines are timestamped to stderr so duration of each phase is visible at a glance.

--- a/scripts/dashboard-triage/prompts.py
+++ b/scripts/dashboard-triage/prompts.py
@@ -1,0 +1,98 @@
+"""Prompt templates for dashboard-triage. See SPEC.md for the rationale."""
+
+FIRST_PROMPT = """\
+You are triaging a failed CI workflow run for the 51Degrees engineering team.
+This is ATTEMPT 1 of analysis.
+
+Run context
+-----------
+Repository:        51Degrees/{repo}
+Branch:            {branch}
+Workflow file:     {workflow}
+Run URL:           {run_url}
+Conclusion:        {conclusion}
+Head commit:       {head_sha}
+Commit message:    {head_commit_message}
+Triggered by:      {triggered_by}
+Started at:        {started_at}
+
+The run's logs have been extracted locally to this directory (one .txt
+file per workflow job, possibly inside per-step subfolders):
+  {log_path}
+
+Your environment
+----------------
+- You have NO GitHub authentication. Do not attempt authenticated API calls
+  (no `gh` auth, no GitHub API tokens). Public-only access is fine.
+- Start by listing the log dir: `ls {log_path}` (and `find {log_path} -name '*.txt'`).
+  The names tell you which matrix job/step each file belongs to.
+- Inspect logs with Bash: prefer `grep -ri "error\\|fail\\|exception" {log_path}`,
+  `tail -200`, `head -200`, `awk`/`sed` slices. Do NOT `cat` whole files -
+  they may be large.
+- Use WebFetch against raw.githubusercontent.com to read public source
+  files in 51Degrees repos when relevant.
+
+Your task
+---------
+1. Identify the immediate cause of failure from the logs.
+2. Decide whether this looks like a FLAKY failure (transient infra issue,
+   network hiccup, race condition, timeout with no real cause, runner
+   shortage, package mirror outage) or a REAL failure (test regression,
+   broken build, missing dependency, code bug, configuration error).
+3. Produce a SINGLE concise paragraph (3-5 sentences) describing the cause
+   and a remedy. Where relevant, link to specific source files using full
+   GitHub URLs with line numbers, e.g.
+     https://github.com/51Degrees/{repo}/blob/{head_sha}/path/to/file.cs#L42
+
+Output format
+-------------
+- Your paragraph, then a blank line.
+- If AND ONLY IF you believe this is flakiness that a single rerun is
+  likely to clear, end your output with one final line containing nothing
+  but the token:
+      RERUN
+- If the failure is real, OMIT the RERUN token entirely.
+
+Be terse. No preamble, no apologies, no "I would recommend".
+"""
+
+
+SECOND_PROMPT = """\
+You are triaging a failed CI workflow run for the 51Degrees engineering team.
+This is ATTEMPT 2 - the workflow has ALREADY been rerun once and still
+failed. Do NOT suggest another rerun; this is not flakiness.
+
+Run context
+-----------
+Repository:            51Degrees/{repo}
+Branch:                {branch}
+Workflow file:         {workflow}
+Original run URL:      {run_url}     (conclusion: {conclusion})
+Rerun URL (attempt 2): {rerun_run_url}  (conclusion: {rerun_conclusion})
+Head commit:           {head_sha}
+Commit message:        {head_commit_message}
+Triggered by:          {triggered_by}
+
+The rerun's logs have been extracted locally to this directory (one .txt
+file per workflow job, possibly inside per-step subfolders):
+  {rerun_log_path}
+
+Your environment
+----------------
+- You have NO GitHub authentication. Public-only access.
+- Start with `ls {rerun_log_path}` to see the log files.
+- Inspect logs with Bash slices (`grep -ri`, `tail`, `head`). Do NOT `cat`
+  whole files.
+- Use WebFetch against raw.githubusercontent.com for public source files.
+
+Your task
+---------
+Produce a SINGLE concise paragraph (3-5 sentences) covering:
+- The most likely ROOT CAUSE (not just the surface symptom).
+- A concrete, ACTIONABLE FIX - name files, functions, or config keys.
+  Include full GitHub source URLs with line numbers where they help, e.g.
+     https://github.com/51Degrees/{repo}/blob/{head_sha}/path#Lnn
+
+Be terse and specific. No preamble, no apologies, no "I would recommend",
+no suggestions to rerun.
+"""

--- a/scripts/dashboard-triage/triage.py
+++ b/scripts/dashboard-triage/triage.py
@@ -65,6 +65,8 @@ def require_token() -> None:
         sys.exit("GH_TOKEN not set — run via ./launch_triage.sh")
     anthropic_vars = sorted(k for k in os.environ if k.startswith("ANTHROPIC_"))
     log(f"[env] ANTHROPIC_* vars visible to script: {anthropic_vars or 'none'}")
+    model = os.environ.get("ANTHROPIC_MODEL")
+    log(f"[env] claude --model: {model or '(default, no override)'}")
 
 
 def gh_json(args: list[str]) -> dict | list:
@@ -200,10 +202,13 @@ def claude_env() -> dict[str, str]:
 def claude_analyse(prompt: str) -> str:
     # Pipe the prompt via stdin: --allowed-tools is variadic and would
     # otherwise consume a positional prompt as additional tool names.
+    cmd = ["claude", "-p", "--allowed-tools", "Bash WebFetch"]
+    model = os.environ.get("ANTHROPIC_MODEL")
+    if model:
+        cmd += ["--model", model]
     try:
         result = subprocess.run(
-            ["claude", "-p", "--allowed-tools", "Bash WebFetch"],
-            input=prompt, capture_output=True, text=True,
+            cmd, input=prompt, capture_output=True, text=True,
             env=claude_env(), check=False, timeout=CLAUDE_TIMEOUT_S,
         )
     except subprocess.TimeoutExpired:

--- a/scripts/dashboard-triage/triage.py
+++ b/scripts/dashboard-triage/triage.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""51Degrees CI dashboard triage. See SPEC.md for the design."""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+from prompts import FIRST_PROMPT, SECOND_PROMPT
+
+ORG = "51Degrees"
+SCRIPT_DIR = Path(__file__).resolve().parent
+DASHBOARD_PATH = SCRIPT_DIR.parent.parent / "DASHBOARD.md"
+OUT_DIR = SCRIPT_DIR / "out"
+FAILED_CONCLUSIONS = {"failure", "cancelled", "timed_out", "startup_failure"}
+POLL_INTERVAL_S = 60
+POLL_TIMEOUT_S = 90 * 60
+CLAUDE_WORKERS = 5
+CLAUDE_TIMEOUT_S = 600
+
+
+@dataclass
+class JobResult:
+    category: str
+    repo: str
+    branch: str
+    workflow: str
+    run_id: int = 0
+    conclusion: str = ""
+    run_url: str = ""
+    head_sha: str = ""
+    head_commit_message: str = ""
+    triggered_by: str = ""
+    started_at: str = ""
+    log_path: str | None = None
+    first_analysis: str | None = None
+    flagged_rerun: bool = False
+    rerun_triggered: bool = False
+    rerun_conclusion: str | None = None
+    rerun_run_url: str | None = None
+    rerun_log_path: str | None = None
+    second_analysis: str | None = None
+
+
+_START = time.monotonic()
+
+
+def log(msg: str) -> None:
+    elapsed = time.monotonic() - _START
+    stamp = dt.datetime.now().strftime("%H:%M:%S")
+    print(f"[{stamp} +{elapsed:7.1f}s] {msg}", file=sys.stderr, flush=True)
+
+
+def require_token() -> None:
+    if not os.environ.get("GH_TOKEN"):
+        sys.exit("GH_TOKEN not set — run via ./launch_triage.sh")
+
+
+def gh_json(args: list[str]) -> dict | list:
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} -> {result.stderr.strip()}")
+    return json.loads(result.stdout) if result.stdout.strip() else {}
+
+
+# ----------------------------- parse -----------------------------
+
+ROW_RE = re.compile(
+    r"^\|\s*\[([^\]]+)\]\(https://github\.com/51Degrees/([^)]+)\)\s*\|"
+    r"\s*`([^`]+)`\s*\|\s*(.+?)\s*\|\s*$"
+)
+WORKFLOW_RE = re.compile(r"actions/workflows/([^/]+\.yml)/badge\.svg")
+HEADING_RE = re.compile(r"^###\s+(.+?)\s*$")
+
+
+def parse_dashboard() -> list[JobResult]:
+    text = DASHBOARD_PATH.read_text()
+    jobs: list[JobResult] = []
+    category = ""
+    for line in text.splitlines():
+        m_h = HEADING_RE.match(line)
+        if m_h:
+            category = m_h.group(1).strip()
+            continue
+        m_r = ROW_RE.match(line)
+        if not m_r:
+            continue
+        _, repo, branch, status_cell = m_r.groups()
+        for wf in dict.fromkeys(WORKFLOW_RE.findall(status_cell)):
+            jobs.append(JobResult(
+                category=category, repo=repo.strip(),
+                branch=branch.strip(), workflow=wf,
+            ))
+    return jobs
+
+
+# ----------------------------- probe -----------------------------
+
+def probe_runs(jobs: list[JobResult]) -> list[JobResult]:
+    failed: list[JobResult] = []
+    for job in jobs:
+        try:
+            resp = gh_json([
+                "api",
+                f"repos/{ORG}/{job.repo}/actions/workflows/"
+                f"{job.workflow}/runs?branch={job.branch}&per_page=1",
+            ])
+        except RuntimeError as e:
+            log(f"[probe] skip {job.repo}/{job.workflow}: {e}")
+            continue
+        runs = resp.get("workflow_runs", []) if isinstance(resp, dict) else []
+        if not runs:
+            continue
+        r = runs[0]
+        if r.get("status") != "completed":
+            continue
+        conclusion = r.get("conclusion") or ""
+        if conclusion not in FAILED_CONCLUSIONS:
+            continue
+        job.run_id = r["id"]
+        job.conclusion = conclusion
+        job.run_url = r.get("html_url", "")
+        job.head_sha = r.get("head_sha", "")
+        commit_msg = ((r.get("head_commit") or {}).get("message") or "").strip()
+        job.head_commit_message = commit_msg.splitlines()[0] if commit_msg else ""
+        actor = r.get("triggering_actor") or r.get("actor") or {}
+        job.triggered_by = actor.get("login", "") or "(unknown)"
+        job.started_at = r.get("run_started_at") or r.get("created_at", "")
+        failed.append(job)
+    return failed
+
+
+# ----------------------------- logs -----------------------------
+
+def fetch_log(job: JobResult, tmp_dir: Path, *, rerun: bool = False) -> str | None:
+    """Download the logs zip via the GH API and extract it to a per-run dir.
+
+    Returns the absolute path of the extracted directory. Claude reads files
+    from there with `ls`/`grep`/`head`/`tail`.
+    """
+    suffix = "-rerun" if rerun else ""
+    safe_wf = job.workflow.replace("/", "_")
+    log_dir = tmp_dir / f"{job.repo}-{safe_wf}-{job.run_id}{suffix}"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = log_dir / "_logs.zip"
+    with open(zip_path, "wb") as fp:
+        result = subprocess.run(
+            ["gh", "api",
+             f"repos/{ORG}/{job.repo}/actions/runs/{job.run_id}/logs"],
+            stdout=fp, stderr=subprocess.PIPE, check=False,
+        )
+    if result.returncode != 0 or zip_path.stat().st_size == 0:
+        log(f"[log] {job.repo} run {job.run_id}: {result.stderr.decode().strip()}")
+        zip_path.unlink(missing_ok=True)
+        return None
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(log_dir)
+    except zipfile.BadZipFile:
+        log(f"[log] {job.repo} run {job.run_id}: bad zip")
+        return None
+    finally:
+        zip_path.unlink(missing_ok=True)
+    return str(log_dir)
+
+
+def fetch_logs(jobs: list[JobResult], tmp_dir: Path) -> None:
+    for job in jobs:
+        job.log_path = fetch_log(job, tmp_dir)
+
+
+def fetch_rerun_logs(jobs: list[JobResult], tmp_dir: Path) -> None:
+    for job in jobs:
+        if job.rerun_triggered and job.rerun_conclusion not in ("success", None):
+            job.rerun_log_path = fetch_log(job, tmp_dir, rerun=True)
+
+
+# ----------------------------- claude -----------------------------
+
+def claude_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("GH_TOKEN", None)
+    env.pop("GITHUB_TOKEN", None)
+    return env
+
+
+def claude_analyse(prompt: str) -> str:
+    # Pipe the prompt via stdin: --allowed-tools is variadic and would
+    # otherwise consume a positional prompt as additional tool names.
+    try:
+        result = subprocess.run(
+            ["claude", "-p", "--allowed-tools", "Bash WebFetch"],
+            input=prompt, capture_output=True, text=True,
+            env=claude_env(), check=False, timeout=CLAUDE_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return f"[claude timeout after {CLAUDE_TIMEOUT_S}s]"
+    if result.returncode != 0:
+        return f"[claude error: {result.stderr.strip() or 'no output'}]"
+    return result.stdout.strip()
+
+
+def _job_fields(job: JobResult) -> dict[str, str]:
+    return {
+        "repo": job.repo,
+        "branch": job.branch,
+        "workflow": job.workflow,
+        "run_url": job.run_url,
+        "conclusion": job.conclusion,
+        "head_sha": job.head_sha,
+        "head_commit_message": (job.head_commit_message or "")[:200],
+        "triggered_by": job.triggered_by or "(unknown)",
+        "started_at": job.started_at,
+        "log_path": job.log_path or "(log unavailable — work from the run URL only)",
+        "rerun_run_url": job.rerun_run_url or "",
+        "rerun_conclusion": job.rerun_conclusion or "",
+        "rerun_log_path": job.rerun_log_path or "(log unavailable)",
+    }
+
+
+def _strip_rerun_sentinel(out: str) -> tuple[str, bool]:
+    lines = out.splitlines()
+    while lines and not lines[-1].strip():
+        lines.pop()
+    if lines and lines[-1].strip() == "RERUN":
+        lines.pop()
+        return "\n".join(lines).rstrip(), True
+    return out, False
+
+
+def first_pass_analyse(jobs: list[JobResult]) -> None:
+    def analyse(job: JobResult) -> None:
+        out = claude_analyse(FIRST_PROMPT.format(**_job_fields(job)))
+        cleaned, flagged = _strip_rerun_sentinel(out)
+        job.first_analysis = cleaned
+        job.flagged_rerun = flagged
+
+    with ThreadPoolExecutor(max_workers=CLAUDE_WORKERS) as pool:
+        list(pool.map(analyse, jobs))
+
+
+def second_pass_analyse(jobs: list[JobResult]) -> None:
+    targets = [
+        j for j in jobs
+        if j.rerun_triggered and j.rerun_conclusion not in ("success", None)
+    ]
+
+    def analyse(job: JobResult) -> None:
+        job.second_analysis = claude_analyse(SECOND_PROMPT.format(**_job_fields(job)))
+
+    with ThreadPoolExecutor(max_workers=CLAUDE_WORKERS) as pool:
+        list(pool.map(analyse, targets))
+
+
+# ----------------------------- rerun + poll -----------------------------
+
+def rerun_flaky(jobs: list[JobResult]) -> None:
+    for job in jobs:
+        if not job.flagged_rerun:
+            continue
+        result = subprocess.run(
+            ["gh", "run", "rerun", str(job.run_id),
+             "--repo", f"{ORG}/{job.repo}"],
+            capture_output=True, text=True, check=False,
+        )
+        if result.returncode == 0:
+            job.rerun_triggered = True
+        else:
+            log(f"[rerun] {job.repo} {job.run_id}: {result.stderr.strip()}")
+
+
+def poll_reruns(jobs: list[JobResult]) -> None:
+    pending = [j for j in jobs if j.rerun_triggered]
+    if not pending:
+        return
+    deadline = {id(j): time.time() + POLL_TIMEOUT_S for j in pending}
+    while pending:
+        time.sleep(POLL_INTERVAL_S)
+        still: list[JobResult] = []
+        for job in pending:
+            if time.time() > deadline[id(job)]:
+                job.rerun_conclusion = "timed_out_polling"
+                continue
+            try:
+                data = gh_json([
+                    "run", "view", str(job.run_id),
+                    "--repo", f"{ORG}/{job.repo}",
+                    "--json", "status,conclusion,url",
+                ])
+            except RuntimeError as e:
+                log(f"[poll] {job.repo} {job.run_id}: {e}")
+                still.append(job)
+                continue
+            if isinstance(data, dict) and data.get("status") == "completed":
+                job.rerun_conclusion = data.get("conclusion") or "unknown"
+                job.rerun_run_url = data.get("url") or job.run_url
+            else:
+                still.append(job)
+        pending = still
+
+
+# ----------------------------- report -----------------------------
+
+def write_report(jobs: list[JobResult]) -> Path:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = dt.datetime.now().strftime("%Y-%m-%d-%H%M")
+    path = OUT_DIR / f"report-{stamp}.md"
+
+    passed = [j for j in jobs if j.rerun_triggered and j.rerun_conclusion == "success"]
+    failed_after = [j for j in jobs if j.rerun_triggered and j.rerun_conclusion != "success"]
+    no_rerun = [j for j in jobs if not j.rerun_triggered]
+
+    lines: list[str] = [
+        f"# 51Degrees CI dashboard triage — {stamp}",
+        "",
+        f"- Failed jobs detected: **{len(jobs)}**",
+        f"- Passed after rerun: **{len(passed)}**",
+        f"- Failed after rerun: **{len(failed_after)}**",
+        f"- Real failures (no rerun): **{len(no_rerun)}**",
+        "",
+    ]
+
+    def hdr(j: JobResult) -> str:
+        return f"### [{j.repo}]({j.run_url}) — `{j.workflow}` ({j.conclusion})"
+
+    if passed:
+        lines += ["## Passed after rerun", ""]
+        for j in passed:
+            lines.append(
+                f"- **{j.repo}** `{j.workflow}` — "
+                f"[original]({j.run_url}) -> [rerun]({j.rerun_run_url})"
+            )
+        lines.append("")
+
+    if failed_after:
+        lines += ["## Failed after rerun", ""]
+        for j in failed_after:
+            lines += [
+                hdr(j),
+                f"Rerun: **{j.rerun_conclusion}** — {j.rerun_run_url}",
+                f"Commit `{j.head_sha[:8]}` — {j.head_commit_message[:140]}",
+                "",
+                j.second_analysis or "_(no analysis)_",
+                "",
+            ]
+
+    if no_rerun:
+        lines += ["## Failed, not flagged as flaky", ""]
+        for j in no_rerun:
+            lines += [
+                hdr(j),
+                f"Commit `{j.head_sha[:8]}` — {j.head_commit_message[:140]}",
+                "",
+                j.first_analysis or "_(no analysis)_",
+                "",
+            ]
+
+    path.write_text("\n".join(lines))
+    return path
+
+
+# ----------------------------- main -----------------------------
+
+def main() -> int:
+    require_token()
+    if not DASHBOARD_PATH.exists():
+        sys.exit(f"DASHBOARD.md not found at {DASHBOARD_PATH}")
+
+    jobs = parse_dashboard()
+    log(f"[parse] {len(jobs)} (repo, workflow) tuples")
+
+    failed = probe_runs(jobs)
+    log(f"[probe] {len(failed)} failed runs")
+    if not failed:
+        OUT_DIR.mkdir(parents=True, exist_ok=True)
+        stamp = dt.datetime.now().strftime("%Y-%m-%d-%H%M")
+        path = OUT_DIR / f"report-{stamp}.md"
+        path.write_text(
+            f"# 51Degrees CI dashboard triage — {stamp}\n\nNo failures detected.\n"
+        )
+        log(f"[report] {path}")
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="dashboard-triage-") as tmp:
+        tmp_dir = Path(tmp)
+        fetch_logs(failed, tmp_dir)
+        with_log = sum(1 for j in failed if j.log_path)
+        log(f"[logs] {with_log}/{len(failed)} downloaded")
+
+        first_pass_analyse(failed)
+        flagged = [j for j in failed if j.flagged_rerun]
+        log(f"[pass1] {len(flagged)}/{len(failed)} flagged for rerun")
+
+        rerun_flaky(failed)
+        triggered = [j for j in failed if j.rerun_triggered]
+        log(f"[rerun] {len(triggered)} triggered")
+
+        poll_reruns(failed)
+        passed = sum(1 for j in triggered if j.rerun_conclusion == "success")
+        log(f"[poll] {passed} passed, {len(triggered) - passed} still failed")
+
+        fetch_rerun_logs(failed, tmp_dir)
+        second_pass_analyse(failed)
+        analysed = sum(1 for j in failed if j.second_analysis)
+        log(f"[pass2] {analysed} post-rerun failures analysed")
+
+        path = write_report(failed)
+
+    log(f"[report] {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dashboard-triage/triage.py
+++ b/scripts/dashboard-triage/triage.py
@@ -63,6 +63,8 @@ def log(msg: str) -> None:
 def require_token() -> None:
     if not os.environ.get("GH_TOKEN"):
         sys.exit("GH_TOKEN not set — run via ./launch_triage.sh")
+    anthropic_vars = sorted(k for k in os.environ if k.startswith("ANTHROPIC_"))
+    log(f"[env] ANTHROPIC_* vars visible to script: {anthropic_vars or 'none'}")
 
 
 def gh_json(args: list[str]) -> dict | list:
@@ -205,10 +207,17 @@ def claude_analyse(prompt: str) -> str:
             env=claude_env(), check=False, timeout=CLAUDE_TIMEOUT_S,
         )
     except subprocess.TimeoutExpired:
+        log("[claude] timeout")
         return f"[claude timeout after {CLAUDE_TIMEOUT_S}s]"
     if result.returncode != 0:
-        return f"[claude error: {result.stderr.strip() or 'no output'}]"
-    return result.stdout.strip()
+        err = (result.stderr.strip() or result.stdout.strip() or "no output")[:400]
+        log(f"[claude] rc={result.returncode}: {err}")
+        return f"[claude error rc={result.returncode}: {err}]"
+    out = result.stdout.strip()
+    if not out:
+        log(f"[claude] empty stdout; stderr: {result.stderr.strip()[:300]}")
+        return "[claude returned empty output]"
+    return out
 
 
 def _job_fields(job: JobResult) -> dict[str, str]:
@@ -239,6 +248,10 @@ def _strip_rerun_sentinel(out: str) -> tuple[str, bool]:
     return out, False
 
 
+def _is_claude_error(text: str | None) -> bool:
+    return bool(text) and text.startswith(("[claude error", "[claude timeout", "[claude returned empty"))
+
+
 def first_pass_analyse(jobs: list[JobResult]) -> None:
     def analyse(job: JobResult) -> None:
         out = claude_analyse(FIRST_PROMPT.format(**_job_fields(job)))
@@ -248,6 +261,9 @@ def first_pass_analyse(jobs: list[JobResult]) -> None:
 
     with ThreadPoolExecutor(max_workers=CLAUDE_WORKERS) as pool:
         list(pool.map(analyse, jobs))
+    errs = sum(1 for j in jobs if _is_claude_error(j.first_analysis))
+    if errs:
+        log(f"[pass1] WARNING: {errs}/{len(jobs)} analyses failed (claude returned error/empty)")
 
 
 def second_pass_analyse(jobs: list[JobResult]) -> None:
@@ -261,6 +277,9 @@ def second_pass_analyse(jobs: list[JobResult]) -> None:
 
     with ThreadPoolExecutor(max_workers=CLAUDE_WORKERS) as pool:
         list(pool.map(analyse, targets))
+    errs = sum(1 for j in targets if _is_claude_error(j.second_analysis))
+    if errs:
+        log(f"[pass2] WARNING: {errs}/{len(targets)} analyses failed (claude returned error/empty)")
 
 
 # ----------------------------- rerun + poll -----------------------------


### PR DESCRIPTION
Daily-scheduled agent that triages failing CI runs listed in `DASHBOARD.md`.

See [`scripts/dashboard-triage/README.md`](scripts/dashboard-triage/README.md) for runbook, secrets, and scheduled-run setup, and [`scripts/dashboard-triage/SPEC.md`](scripts/dashboard-triage/SPEC.md) for design.

## Changes
- New pipeline under `scripts/dashboard-triage/` (probe → analyse → rerun once → re-analyse → report).
- Report is added directly to the workflow run summary.
- Workflow `.github/workflows/dashboard-triage.yml` — `workflow_dispatch` + cron.
