### PR TITLE
Flag stale documentation versions in utm-lint

### DIFF
--- a/scripts/utm-lint.ps1
+++ b/scripts/utm-lint.ps1
@@ -34,7 +34,10 @@ Per-repo configuration is read from .utm-lint.json at the repo root:
 param(
     [string]$RepoRoot = ".",
     [string]$Campaign = "",
-    [string]$ConfigPath = ""
+    [string]$ConfigPath = "",
+    # The current documentation site version. Versioned documentation
+    # links must use this version or none at all.
+    [string]$CurrentDocVersion = "4.5"
 )
 
 $ErrorActionPreference = "Stop"
@@ -135,6 +138,14 @@ foreach ($file in $files) {
             if ($rawUrl -imatch 'logo\.ashx') {
                 $violations.Add("$where retired Logo.ashx URL: $rawUrl")
                 continue
+            }
+
+            # Documentation links must use the current version or the
+            # un-versioned URL, never an older version.
+            $docVer = [regex]::Match($rawUrl, '/documentation/(\d+\.\d+)/')
+            if ($docVer.Success -and
+                $docVer.Groups[1].Value -ne $CurrentDocVersion) {
+                $violations.Add("$where stale documentation version $($docVer.Groups[1].Value), use the un-versioned URL or ${CurrentDocVersion}: $rawUrl")
             }
 
             $host51 = $m.Groups[2].Value.ToLowerInvariant()


### PR DESCRIPTION
## Summary

Adds a rule to scripts/utm-lint.ps1, documentation links must use the current documentation version or the un-versioned URL. Any 51degrees.com or docs.51degrees.com link containing /documentation/<version>/ with a version other than the current one is reported as a stale documentation version. The current version defaults to 4.5 and is overridable via -CurrentDocVersion, so a future bump is a one-line change here.

Requested after review found /documentation/4.4/ links across several repositories. Those links have been corrected to un-versioned URLs on the open chore/utm-links branches, and this rule keeps them from coming back.

## Verification

All eighteen tagged repository branches pass with the new rule. Negative test, the rule correctly flags a stale 4.0 link on the legacy docs host in a generated file in cloud-dotnet.