### PR TITLE
Fetch the current IPI Lite data file

### DIFF
--- a/steps/fetch-assets.ps1
+++ b/steps/fetch-assets.ps1
@@ -51,7 +51,7 @@ foreach ($asset in $Assets) {
             Move-Item -Path $_ -Destination $cache
         }
         "51Degrees-LiteIpiV41.ipi" {
-            & $PSScriptRoot/fetch-hash-assets.ps1 -RepoName . -ArchiveName "$_.gz" -Url "https://51ddatafiles.blob.core.windows.net/enterpriseipi/51Degrees-LiteIpiV41.ipi.gz"
+            & $PSScriptRoot/fetch-hash-assets.ps1 -RepoName . -ArchiveName "$_.gz" -Url "https://51ddatafiles.blob.core.windows.net/enterpriseipi/51Degrees-IPIV4LiteIpiV41.ipi.gz"
             Move-Item -Path $_ -Destination $cache
 
         }


### PR DESCRIPTION
## Problem

`steps/fetch-assets.ps1` downloads the `51Degrees-LiteIpiV41.ipi` asset from the blob `enterpriseipi/51Degrees-LiteIpiV41.ipi.gz`. That blob was last modified on 8 April 2026 (served-archive MD5 `E3F5EC950A77A69669C03F4FE0AC4D37`) and carries a data format that current IP Intelligence engines, including released `ip-intelligence` 4.5.41 and engines built from current `ip-intelligence-cxx` main, reject with "The data is an unsupported version".

Any repo that fetches this asset gets an unloadable Lite file. In the 51Degrees IP Intelligence repos this is `ip-intelligence-java` (its `ci/fetch-assets.ps1` lists the asset); the node, dotnet and cxx repos sidestep it by reusing the Enterprise file under the Lite name.

## Fix

The current monthly Lite build is published to the same container under the production naming, `enterpriseipi/51Degrees-IPIV4LiteIpiV41.ipi.gz` (data format 4.5, last modified 2 June 2026). This points the fetch at that blob. The `-ArchiveName` and the unpacked asset name remain `51Degrees-LiteIpiV41.ipi`, so the asset vocabulary is unchanged and consuming repositories need no change.

This mirrors the public-script fix in [ip-intelligence-data#31](https://github.com/51Degrees/ip-intelligence-data/pull/31) and unblocks the `ip-intelligence-java` CI change that links the fetched Lite file under the name the test helpers expect.

## Verification

- The new blob is byte-identical to the June 2026 production build on the internal store (MD5 `C6F414FB7ED0A8A0C82C8B6971321349`).
- The unpacked file loads with `ip-intelligence` 4.5.41 and with the engine built from the pinned `ip-intelligence-cxx` commit; the `ip-intelligence-java` on-premise test suite is fully green against it (22 run, 0 failures, 2 expected skips), where the old blob produced 14 unsupported-version errors.

## Note for data owners

Once consumers are repointed, the stale `51Degrees-LiteIpiV41.ipi.gz` blob should be removed or refreshed (see ip-intelligence-data issues #28 and #30) so stale links fail loudly rather than serving an unloadable file.