### PR TITLE
Add forbid mode to utm-lint for published-content repos

### DIFF
--- a/scripts/utm-lint.ps1
+++ b/scripts/utm-lint.ps1
@@ -54,10 +54,22 @@ if ($Campaign -eq "") {
 if ($ConfigPath -eq "") { $ConfigPath = Join-Path $RepoRoot ".utm-lint.json" }
 $configExclude = @()
 $allowUntagged = @()
+# Mode: "require" (default) means navigational 51degrees.com links must
+# carry the full UTM scheme. "forbid" is the inverse, for repositories
+# whose content is published ON 51degrees.com (for example the
+# documentation site): their links to 51degrees.com are internal, so a
+# UTM tag would overwrite campaign attribution and trip SEO duplicate-URL
+# checks. In forbid mode any UTM tag on a 51degrees.com link is a
+# violation and untagged links are correct.
+$mode = "require"
 if (Test-Path $ConfigPath) {
     $config = Get-Content $ConfigPath -Raw | ConvertFrom-Json
     if ($config.exclude) { $configExclude = @($config.exclude) }
     if ($config.allowUntagged) { $allowUntagged = @($config.allowUntagged) }
+    if ($config.mode) { $mode = $config.mode }
+}
+if ($mode -notin @("require", "forbid")) {
+    throw "Unknown mode '$mode' in $ConfigPath (expected 'require' or 'forbid')."
 }
 
 # Paths never scanned. Tests hold fixture URLs, generated and vendored
@@ -170,6 +182,16 @@ foreach ($file in $files) {
             }
             if ($host51.StartsWith('www.')) {
                 $violations.Add("$where www host, use the bare domain: $rawUrl")
+            }
+
+            # Forbid mode: this repository's content is served from
+            # 51degrees.com, so links to it are internal and must not be
+            # UTM-tagged. The https/www/version checks above still apply.
+            if ($mode -eq "forbid") {
+                if ($hasUtm) {
+                    $violations.Add("$where UTM parameters on an internal 51degrees.com link (this repository publishes to 51degrees.com, so its links are internal and must not be tagged): $rawUrl")
+                }
+                continue
             }
 
             if (-not $hasUtm) {


### PR DESCRIPTION
## Summary

Adds a `mode` option to `scripts/utm-lint.ps1`. The default `require` mode is unchanged (navigational 51degrees.com links must carry the five-parameter UTM scheme). The new `forbid` mode is its inverse, for repositories whose content is published ON 51degrees.com.

The documentation repository publishes to 51degrees.com/documentation/, so its links to 51degrees.com are internal. A UTM tag on an internal link overwrites the visit's campaign attribution and creates duplicate-URL variants that SEO checks flag. In `forbid` mode any UTM tag on a 51degrees.com or configure.51degrees.com link is a violation, and untagged links are correct. The https, www and stale-documentation-version checks still run, because those matter for an internal site too.

A repository opts in with `{ "mode": "forbid" }` in its `.utm-lint.json`. Mode defaults to `require`, so every existing repository is unaffected.

## Verification

Require mode still clean on the tagged repositories. Forbid mode against the documentation repository correctly flags the one UTM-tagged README link and two pre-existing http internal links (fixed in the documentation PR).