### PR TITLE
Add pypi to the utm-lint source vocabulary

### DIFF
--- a/scripts/utm-lint.ps1
+++ b/scripts/utm-lint.ps1
@@ -105,7 +105,7 @@ $urlAllowlist = @('million\.zip', '/reflector/', 'datareceiver',
 # Functional hosts that must never carry campaign parameters.
 $excludedHostPattern = '^(cloud|distributor|devices-v4|bulkdata|docs|legacy|ipcloud|crm[\w-]*|srv[\w-]*)\.51degrees\.com$'
 
-$sources = 'github|code|nuget|npm|maven|packagist'
+$sources = 'github|code|nuget|npm|maven|packagist|pypi'
 $mediums = 'readme|docs|example|comment|package'
 $slug = '[a-z0-9][a-z0-9._-]*'
 $campaignEscaped = [regex]::Escape($Campaign)


### PR DESCRIPTION
## Summary

Adds `pypi` to the closed `utm_source` set in `scripts/utm-lint.ps1`, alongside the existing `nuget`, `npm`, `maven` and `packagist` package sources. Python package metadata (the `url` in setup.py / setup.cfg / pyproject) renders as the project homepage on PyPI, so a link to 51degrees.com there is navigational package metadata and takes `utm_source=pypi&utm_medium=package`.

Needed for the Python repository rollout (device-detection-python, pipeline-python, location-python). location-python's setup.py already has `url="https://51degrees.com/"`.