### PR TITLE
Add central resource-key environment step

### DIFF
--- a/nightly-publish.test.ps1
+++ b/nightly-publish.test.ps1
@@ -36,6 +36,10 @@ Write-Host "::group::Setup Environment"
 ./steps/run-script.ps1 ./$RepoName/ci/setup-environment.ps1 $Options
 Write-Host "::endgroup::"
 
+Write-Host "::group::Set Resource Keys"
+./steps/set-resource-keys.ps1 -Keys $Options.Keys
+Write-Host "::endgroup::"
+
 Write-Host "::group::Install Package From Artifact"
 ./steps/run-script.ps1 ./$RepoName/ci/install-package.ps1  $Options
 Write-Host "::endgroup::"

--- a/nightly-pull-request.build-and-test.ps1
+++ b/nightly-pull-request.build-and-test.ps1
@@ -53,6 +53,10 @@ Write-Host "::group::Setup Environment"
 ./steps/run-script.ps1 ./$RepoName/ci/setup-environment.ps1 $Options
 Write-Host "::endgroup::"
 
+Write-Host "::group::Set Resource Keys"
+./steps/set-resource-keys.ps1 -Keys $Options.Keys
+Write-Host "::endgroup::"
+
 Write-Host "::group::Build Project"
 ./steps/run-script.ps1 ./$RepoName/ci/build-project.ps1 $Options
 Write-Host "::endgroup::"

--- a/steps/README.md
+++ b/steps/README.md
@@ -131,6 +131,15 @@ The `RepoName`, `OrgName`, and `DryRun` parameters will always be available to t
 
 For a more detailed description of options usage, see [Options](/DESIGN.md#build-options).
 
+## Set Resource Keys
+**Script: `set-resource-keys.ps1`**
+
+Exports the 51Degrees resource key secrets as environment variables for the steps and tests that follow.
+
+Takes the secrets available to the job as a hashtable (in the framework this is `$Options.Keys`) and exports every key whose name follows the resource-key convention (any name beginning with `_51DEGREES_RESOURCE_KEY`, for example `_51DEGREES_RESOURCE_KEY_FREE` and `_51DEGREES_RESOURCE_KEY_PAID`). Each is set in the process environment and, under GitHub Actions, appended to `$GITHUB_ENV`.
+
+This is the single, central place that knows the resource-key convention. To make a new resource key available to every repository, add the secret at the organisation level using the `_51DEGREES_RESOURCE_KEY_*` convention; it is picked up automatically with no change to any repository's CI. Secret values are never written to the log.
+
 ## Update Sub-Modules
 **Script: `update-sub-modules.ps1`**
 

--- a/steps/set-resource-keys.ps1
+++ b/steps/set-resource-keys.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+    Exports 51Degrees resource key secrets as environment variables for the
+    steps and tests that follow.
+
+.DESCRIPTION
+    51Degrees cloud tests read their resource key from an environment variable.
+    Some read a single key; others (for example the 51Did cloud test) iterate
+    over every available tier, running once per key. Rather than have each
+    repository wire the keys up in its own CI, this is the single, central place
+    that knows the resource-key naming convention and makes the keys available
+    everywhere.
+
+    Every supplied secret whose name matches the resource-key convention (by
+    default any name beginning with "_51DEGREES_RESOURCE_KEY", e.g. the
+    organisation secrets _51DEGREES_RESOURCE_KEY_FREE and
+    _51DEGREES_RESOURCE_KEY_PAID) is exported:
+      * to the current process environment, so later scripts in the same job
+        (build-project, run-unit-tests, run-integration-tests, ...) inherit it;
+      * and, when running under GitHub Actions, appended to $GITHUB_ENV, so
+        later steps in the same job inherit it too.
+
+    To make a NEW resource key available to every repository, add the secret at
+    the organisation level following the _51DEGREES_RESOURCE_KEY_* convention.
+    It is picked up here automatically, with no change to any repository's CI.
+
+    Secret values are never written to the log; GitHub masks registered secret
+    values regardless.
+
+.PARAMETER Keys
+    The secrets available to the job, as a hashtable of name -> value. In the
+    common-ci framework this is the $Options.Keys hashtable (the secrets
+    context passed in as ${{ toJSON(secrets) }}).
+
+.PARAMETER Prefix
+    The naming convention that identifies a resource key. Any supplied key whose
+    name begins with this prefix (case-insensitively) is exported. This is the
+    central knob for the convention.
+#>
+param(
+    [hashtable]$Keys = @{},
+    [string]$Prefix = "_51DEGREES_RESOURCE_KEY"
+)
+$ErrorActionPreference = "Stop"
+
+if ($null -eq $Keys -or $Keys.Count -eq 0) {
+    Write-Host "No keys supplied; no resource key environment variables to set."
+    return
+}
+
+$exported = [System.Collections.Generic.List[string]]::new()
+foreach ($entry in $Keys.GetEnumerator()) {
+    $name = [string]$entry.Key
+    $value = [string]$entry.Value
+
+    if ($name -notlike "$Prefix*") { continue }
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        Write-Host "Skipping '$name': no value (secret not set)."
+        continue
+    }
+
+    # Process environment: inherited by later scripts in this same job.
+    Set-Item -Path "Env:$name" -Value $value
+
+    # GitHub Actions environment file: inherited by later steps in this job.
+    # Resource keys are single-line tokens, so a plain name=value line is safe.
+    if (-not [string]::IsNullOrEmpty($env:GITHUB_ENV)) {
+        "$name=$value" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    }
+
+    $exported.Add($name)
+}
+
+if ($exported.Count -gt 0) {
+    Write-Host "Set $($exported.Count) resource key environment variable(s): $($exported -join ', ')"
+}
+else {
+    Write-Host "No keys matching '$Prefix*' were supplied; nothing to set."
+}


### PR DESCRIPTION
## What

Adds a single, central place that exposes 51Degrees resource keys to every repository's CI tests.

- **`steps/set-resource-keys.ps1`** (new) — takes the job's secrets as a hashtable and exports every secret whose name follows the resource-key convention (any name beginning with `_51DEGREES_RESOURCE_KEY`, e.g. `_51DEGREES_RESOURCE_KEY_FREE`, `_51DEGREES_RESOURCE_KEY_PAID`) to:
  - the **process environment**, so later scripts in the same job (build / unit / integration tests) inherit it;
  - **`$GITHUB_ENV`**, so later steps in the same job inherit it.
- Wired into both test orchestrators right after **Setup Environment**, before the test steps:
  - `nightly-pull-request.build-and-test.ps1` (PR flow)
  - `nightly-publish.test.ps1` (publish flow)

  Both already expand the secrets into `$Options`, so the call is just `./steps/set-resource-keys.ps1 -Keys $Options.Keys`.
- Documented in `steps/README.md`.

## Why

Resource keys were wired up per-repository (and, for standalone workflows, hardcoded by name). This makes adding a new key a multi-repo change.

With this, the convention lives in one place. **To make a new resource key available to every repository, add the secret at the organisation level using the `_51DEGREES_RESOURCE_KEY_*` convention** — it is picked up automatically, with no change to any repository's CI.

## Notes

- Secret **values** are never written to the log (GitHub masks registered secrets regardless); only the names of the variables that were set are logged.
- Empty / no matching keys is a **safe no-op**, so this cannot break a build that has no resource-key secrets (e.g. forked PRs).
- The legacy single `SUPER_RESOURCE_KEY` is intentionally **not** exported here (different convention); repositories that use it keep their existing wiring.

## Verification

- All three changed/added scripts pass the PowerShell parser.
- End-to-end: building `$Options` exactly as the orchestrators do (`$Options += $Options.Keys`) and calling `set-resource-keys.ps1 -Keys $Options.Keys` exports `_51DEGREES_RESOURCE_KEY_FREE` and `_51DEGREES_RESOURCE_KEY_PAID` to the process env and `$GITHUB_ENV`, and correctly ignores non-resource-key secrets (`token`, `SUPER_RESOURCE_KEY`).
