### PR TITLE
Allow docs.rs as a UTM source

### DIFF
--- a/scripts/utm-lint.ps1
+++ b/scripts/utm-lint.ps1
@@ -105,7 +105,7 @@ $urlAllowlist = @('million\.zip', '/reflector/', 'datareceiver',
 # Functional hosts that must never carry campaign parameters.
 $excludedHostPattern = '^(cloud|distributor|devices-v4|bulkdata|docs|legacy|ipcloud|crm[\w-]*|srv[\w-]*)\.51degrees\.com$'
 
-$sources = 'github|code|nuget|npm|maven|packagist|pypi'
+$sources = 'github|code|nuget|npm|maven|packagist|pypi|docs\.rs'
 $mediums = 'readme|docs|example|comment|package'
 $slug = '[a-z0-9][a-z0-9._-]*'
 $campaignEscaped = [regex]::Escape($Campaign)


### PR DESCRIPTION
Rust crates link from their docs.rs documentation pages, so add `docs.rs` to the allowed `utm_source` values in the UTM link lint. Enables tagging docs.rs-originated links (for example a logo on a crate's docs.rs page) as `utm_source=docs.rs`.