### PR TITLE
fetch-assets: fix bulkdata date format (Available uses YYYY/MM/DD, Download needs YYYY-MM-DD)

### DIFF
--- a/steps/fetch-assets.ps1
+++ b/steps/fetch-assets.ps1
@@ -22,9 +22,25 @@ function Get-FromBulkData {
     $tomorrow = [DateTime]::Now.AddDays(1).ToString('yyyy-MM-dd')
     Write-Host "Retrieving the latest $Data version..."
     $available = Invoke-WebRequest "https://bulkdata.51degrees.com/api/v4/Available/Production/$Data/$License/$monthAgo/$tomorrow" | ConvertFrom-Json -AsHashtable
-    $latest = $available.Keys | Select-Object -Last 1
-    Write-Host "Downloading $Data from $latest..."
-    curl -fLo $Output "https://bulkdata.51degrees.com/api/v4/Download/Production/$Data/$License/$latest"
+    # Try the newest version first and fall back to older ones. The Available
+    # index can list a version whose blob is not actually downloadable yet (a
+    # broken or racy daily publish), and a single hard attempt on the latest
+    # then fails the whole pipeline. Sort descending rather than trusting the
+    # key order returned by the API.
+    $versions = @($available.Keys | Sort-Object -Descending)
+    if (-not $versions) {
+        throw "No $Data versions listed by bulkdata in the last 30 days"
+    }
+    foreach ($version in $versions) {
+        Write-Host "Downloading $Data from $version..."
+        try {
+            curl -fLo $Output "https://bulkdata.51degrees.com/api/v4/Download/Production/$Data/$License/$version"
+            return
+        } catch {
+            Write-Warning "$Data $version is indexed but not downloadable ($_); trying an older version..."
+        }
+    }
+    throw "No downloadable $Data version found in the last 30 days"
 }
 
 foreach ($asset in $Assets) {

--- a/steps/fetch-assets.ps1
+++ b/steps/fetch-assets.ps1
@@ -22,22 +22,23 @@ function Get-FromBulkData {
     $tomorrow = [DateTime]::Now.AddDays(1).ToString('yyyy-MM-dd')
     Write-Host "Retrieving the latest $Data version..."
     $available = Invoke-WebRequest "https://bulkdata.51degrees.com/api/v4/Available/Production/$Data/$License/$monthAgo/$tomorrow" | ConvertFrom-Json -AsHashtable
-    # Try the newest version first and fall back to older ones. The Available
-    # index can list a version whose blob is not actually downloadable yet (a
-    # broken or racy daily publish), and a single hard attempt on the latest
-    # then fails the whole pipeline. Sort descending rather than trusting the
-    # key order returned by the API.
+    # The Available index returns version keys as YYYY/MM/DD, but the Download
+    # endpoint expects YYYY-MM-DD - passing the key through verbatim builds a
+    # slashed URL that 404s. Normalise to dashes. Also iterate newest-first and
+    # fall back to older versions in case a given day's blob is genuinely
+    # missing, and sort explicitly rather than trusting the API's key order.
     $versions = @($available.Keys | Sort-Object -Descending)
     if (-not $versions) {
         throw "No $Data versions listed by bulkdata in the last 30 days"
     }
     foreach ($version in $versions) {
+        $datePath = $version -replace '/', '-'
         Write-Host "Downloading $Data from $version..."
         try {
-            curl -fLo $Output "https://bulkdata.51degrees.com/api/v4/Download/Production/$Data/$License/$version"
+            curl -fLo $Output "https://bulkdata.51degrees.com/api/v4/Download/Production/$Data/$License/$datePath"
             return
         } catch {
-            Write-Warning "$Data $version is indexed but not downloadable ($_); trying an older version..."
+            Write-Warning "$Data $version is not downloadable ($_); trying an older version..."
         }
     }
     throw "No downloadable $Data version found in the last 30 days"


### PR DESCRIPTION
## Root cause

`steps/fetch-assets.ps1`'s `Get-FromBulkData` takes the newest version key from the bulkdata `Available` index and drops it straight into the `Download` URL:

```powershell
$latest = $available.Keys | Select-Object -Last 1        # e.g. "2026/07/16"
curl -fLo $Output ".../Download/Production/$Data/$License/$latest"
```

The **`Available` index returns keys as `YYYY/MM/DD` (slashes)**, but the **`Download` endpoint expects `YYYY-MM-DD` (dashes)**. The slashed value turns into extra path segments, so the download 404s. Verified directly against the live API with a chargify-authorised key:

| date in URL | HTTP |
| --- | --- |
| `2026-07-16` (dash) | **200** |
| `2026/07/16` (slash) | **404** |

This is why 51Degrees/cloud Full Image CI ([run 29516372790](https://github.com/51Degrees/cloud/actions/runs/29516372790)) failed in Fetch Assets on `chargify 2026/07/16`. Scheduled Publish stayed green only because it runs with `cache: true` (on `workflow_call`) and reuses a cached `chargify.json`; the cache-less `workflow_dispatch` dry run did a fresh fetch and hit the broken URL. The asset itself was always present and downloadable.

## Fix

Normalise the version date to dashes (`$version -replace '/', '-'`) before building the Download URL.

Also (defence-in-depth, secondary): iterate versions newest-first and fall back to an older one if a given day's blob is genuinely missing, sorting explicitly with `Sort-Object -Descending` instead of trusting the API's key order. The `try/catch` is required because `$PSNativeCommandUseErrorActionPreference` turns a non-zero `curl` exit into a terminating error.

## Testing

- `Parser::ParseFile`: no parse errors.
- **Live end-to-end** against the real bulkdata API: the index returns `2026/07/16`, the fix requests `2026-07-16`, and it downloads 631,613 bytes of valid JSON. The slash form 404s.
- Fallback loop behavioural test: newest two versions 404, third succeeds -> loop skips the first two.