### PR TITLE
FIX: Point Rust nightly-performance badge link at rust repo

### DIFF
--- a/DASHBOARD.md
+++ b/DASHBOARD.md
@@ -80,4 +80,4 @@
 
 | Repo | Branch | Status |
 | ---- | ------ | ------ |
-| [rust](https://github.com/51Degrees/rust) | `main` | [![Nightly Performance](https://github.com/51Degrees/rust/actions/workflows/nightly-performance.yml/badge.svg)](https://github.com/51Degrees/device-detection-go/actions/workflows/nightly-performance.yml) |
+| [rust](https://github.com/51Degrees/rust) | `main` | [![Nightly Performance](https://github.com/51Degrees/rust/actions/workflows/nightly-performance.yml/badge.svg)](https://github.com/51Degrees/rust/actions/workflows/nightly-performance.yml) |


### PR DESCRIPTION
The Rust row in DASHBOARD.md rendered its status badge from the rust repo's nightly-performance workflow, but the badge's click-through link pointed at device-detection-go. This repoints the link to 51Degrees/rust/actions/workflows/nightly-performance.yml to match the badge image.