### PR TITLE
FIX: Retry stalled or reset GitHub asset downloads

### DIFF
--- a/.github/actions/prefetch_assets/action.yml
+++ b/.github/actions/prefetch_assets/action.yml
@@ -14,10 +14,18 @@ runs:
         id: hash-assets
         shell: pwsh
         env:
+          repo: ${{ inputs.repo }}
           secrets: ${{ inputs.secrets }}
         run: |
           $sha1 = [Security.Cryptography.SHA1Managed]::new()
           $key = ($env:secrets | ConvertFrom-Json -AsHashtable | Select-Object -ExcludeProperty github_token).Values | Sort-Object | Join-String -Separator `n
+          # Fold the repo's fetch-assets script into the key, because it is what
+          # decides which assets are downloaded. Keying on the secrets alone means
+          # the key only rotates once a day, so an entry written before an asset
+          # was added to the list keeps being restored for the rest of that day.
+          # The prefetch step is then skipped on a cache hit and the new asset is
+          # silently missing from the restored cache.
+          $key += "`n" + (Get-Content -Raw "$env:repo/ci/fetch-assets.ps1")
           $hash = [Convert]::ToHexString($sha1.ComputeHash([Text.Encoding]::Utf8.GetBytes($key)))
           "key=$(Get-Date -Format FileDate)-$hash" >> $env:GITHUB_OUTPUT
 

--- a/.github/actions/prefetch_assets/action.yml
+++ b/.github/actions/prefetch_assets/action.yml
@@ -18,7 +18,14 @@ runs:
           secrets: ${{ inputs.secrets }}
         run: |
           $sha1 = [Security.Cryptography.SHA1Managed]::new()
-          $key = ($env:secrets | ConvertFrom-Json -AsHashtable | Select-Object -ExcludeProperty github_token).Values | Sort-Object | Join-String -Separator `n
+          # Select-Object -ExcludeProperty against a hashtable returns an object
+          # with no Values member, so this whole expression used to evaluate to
+          # an empty string and every key carried SHA1("") - the secrets never
+          # took part in the key at all. Drop the token from the hashtable
+          # itself instead.
+          $secretValues = $env:secrets | ConvertFrom-Json -AsHashtable
+          $null = $secretValues.Remove('github_token')
+          $key = $secretValues.Values | Sort-Object | Join-String -Separator `n
           # Fold the repo's fetch-assets script into the key, because it is what
           # decides which assets are downloaded. Keying on the secrets alone means
           # the key only rotates once a day, so an entry written before an asset

--- a/steps/download-data-file.ps1
+++ b/steps/download-data-file.ps1
@@ -13,4 +13,4 @@ if (!$Url -and (!$LicenseKey -or !$DataType -or !$Product)) {
 }
 
 $Url = $Url ? $Url : "https://distributor.51degrees.com/api/v2/download?LicenseKeys=$LicenseKey&Type=$DataType&Download=True&Product=$Product"
-curl -fLo $FullFilePath --connect-timeout 30 --retry 3 $Url
+& $PSScriptRoot/download-with-retry.ps1 -Url $Url -Output $FullFilePath

--- a/steps/download-data-file.ps1
+++ b/steps/download-data-file.ps1
@@ -13,4 +13,4 @@ if (!$Url -and (!$LicenseKey -or !$DataType -or !$Product)) {
 }
 
 $Url = $Url ? $Url : "https://distributor.51degrees.com/api/v2/download?LicenseKeys=$LicenseKey&Type=$DataType&Download=True&Product=$Product"
-& $PSScriptRoot/download-with-retry.ps1 -Url $Url -Output $FullFilePath
+& $PSScriptRoot/download-with-retry.ps1 -Url $Url -Output $FullFilePath -Resume

--- a/steps/download-with-retry.ps1
+++ b/steps/download-with-retry.ps1
@@ -1,0 +1,41 @@
+param (
+    [Parameter(Mandatory)][string]$Url,
+    [Parameter(Mandatory)][string]$Output,
+    # Hard ceiling for a single attempt, in seconds. Only pass this for
+    # downloads of a known, bounded size - the data files are several GB and
+    # any limit generous enough for them on a slow runner would be too coarse
+    # to catch anything, so those rely on the transfer speed floor instead.
+    [int]$MaxTime
+)
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
+
+$curlArguments = @(
+    # --retry alone is not enough: a connection reset (curl 35) is not in
+    # curl's default retry set, which is exactly the failure this guards
+    # against. Note also that no --retry-delay is given on purpose - curl's
+    # default exponential backoff staggers matrix jobs that were all reset at
+    # the same moment, whereas a fixed delay would retry them in lockstep.
+    '--retry', 5, '--retry-all-errors',
+    '--connect-timeout', 30,
+    # Abort an attempt that has trickled below 1KB/s for a minute so that it is
+    # retried, rather than hanging until the job times out or is cancelled.
+    '--speed-limit', 1024, '--speed-time', 60
+)
+if ($MaxTime) {
+    $curlArguments += @('--max-time', $MaxTime)
+}
+
+try {
+    curl -fLo $Output @curlArguments $Url
+} catch {
+    # Never leave a truncated file behind. Callers treat the presence of a file
+    # as proof that the asset is complete, so a partial download would be taken
+    # for a valid cached asset on the next run. Done here rather than with
+    # curl's --remove-on-error because that option needs curl 7.83, and the
+    # ubuntu-22.04 runner image is still on 7.81.
+    if (Test-Path $Output) {
+        Remove-Item -Force $Output
+    }
+    throw
+}

--- a/steps/download-with-retry.ps1
+++ b/steps/download-with-retry.ps1
@@ -5,15 +5,22 @@ param (
     # downloads of a known, bounded size - the data files are several GB and
     # any limit generous enough for them on a slow runner would be too coarse
     # to catch anything, so those rely on the transfer speed floor instead.
-    [int]$MaxTime
+    [int]$MaxTime,
+    # Resume a retry from where the previous attempt stopped instead of
+    # starting again. Worth it for the multi-GB data files, where a runner
+    # pulling at ~1MB/s takes the best part of an hour and restarting from zero
+    # can outlast the job. Curl only sends a Range header once there is partial
+    # data to resume from, so the first attempt is unaffected on a server that
+    # does not support ranges.
+    [switch]$Resume
 )
 $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $true
 
 $curlArguments = @(
-    # --retry alone is not enough: a connection reset (curl 35) is not in
-    # curl's default retry set, which is exactly the failure this guards
-    # against. Note also that no --retry-delay is given on purpose - curl's
+    # --retry alone is not enough: a connection reset (curl 35) and a receive
+    # timeout (curl 56) are not in curl's default retry set, which is exactly
+    # what these downloads keep failing on. Note also that no --retry-delay is given on purpose - curl's
     # default exponential backoff staggers matrix jobs that were all reset at
     # the same moment, whereas a fixed delay would retry them in lockstep.
     '--retry', 5, '--retry-all-errors',
@@ -24,6 +31,9 @@ $curlArguments = @(
 )
 if ($MaxTime) {
     $curlArguments += @('--max-time', $MaxTime)
+}
+if ($Resume) {
+    $curlArguments += @('--continue-at', '-')
 }
 
 try {

--- a/steps/fetch-assets.ps1
+++ b/steps/fetch-assets.ps1
@@ -44,25 +44,6 @@ function Get-FromBulkData {
     throw "No downloadable $Data version found in the last 30 days"
 }
 
-# Several assets are Git LFS objects (the Lite hash file alone is ~28MB) served
-# by GitHub's media host. When the whole build matrix pulls the same object at
-# once GitHub resets or stalls the connection, which failed the job outright
-# because a bare curl has no retry. Note that --retry on its own is not enough:
-# a reset (curl 35) is not in curl's default retry set, hence --retry-all-errors,
-# and --speed-limit/--speed-time turns a stalled transfer into a retry rather
-# than a hang that runs until the job is cancelled.
-function Get-FromGitHub {
-    param (
-        [Parameter(Mandatory)][string]$Url,
-        [Parameter(Mandatory)][string]$Output
-    )
-    $retryArguments = @(
-        '--retry', 5, '--retry-all-errors', '--retry-delay', 5,
-        '--connect-timeout', 30, '--speed-limit', 1024, '--speed-time', 60
-    )
-    curl -fLo $Output @retryArguments $Url
-}
-
 foreach ($asset in $Assets) {
     if (Test-Path $cache/$asset) {
         Write-Host "Asset '$asset' already present in cache, skipping download"
@@ -75,7 +56,7 @@ foreach ($asset in $Assets) {
             Move-Item -Path $_ -Destination $cache
         }
         "51Degrees-LiteV4.1.hash" {
-            Get-FromGitHub -Url "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/51Degrees-LiteV4.1.hash" -Output $cache/$_
+            & $PSScriptRoot/download-with-retry.ps1 -Url "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/51Degrees-LiteV4.1.hash" -Output $cache/$_ -MaxTime 600
         }
         "51Degrees-EnterpriseIpiV41.ipi" {
             & $PSScriptRoot/fetch-hash-assets.ps1 -RepoName . -ArchiveName "$_.gz" -LicenseKey $IpIntelligence -DataType IPIV41 -Product IPIV4Enterprise -Url $IpIntelligenceUrl
@@ -92,10 +73,10 @@ foreach ($asset in $Assets) {
 
         }
         "20000 Evidence Records.yml" {
-            Get-FromGitHub -Url "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/20000%20Evidence%20Records.yml" -Output $cache/$_
+            & $PSScriptRoot/download-with-retry.ps1 -Url "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/20000%20Evidence%20Records.yml" -Output $cache/$_ -MaxTime 600
         }
         "20000 User Agents.csv" {
-            Get-FromGitHub -Url "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/20000%20User%20Agents.csv" -Output $cache/$_
+            & $PSScriptRoot/download-with-retry.ps1 -Url "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/20000%20User%20Agents.csv" -Output $cache/$_ -MaxTime 600
         }
         "51Degrees.csv" {
             & $PSScriptRoot/download-data-file.ps1 -LicenseKey:$DeviceDetection -DataType 'CSV' -Product 'V4TAC' -Url:$CsvUrl -FullFilePath "$_.zip"
@@ -111,7 +92,7 @@ foreach ($asset in $Assets) {
             & $PSScriptRoot/download-data-file.ps1 -LicenseKey:$DeviceDetection -DataType 'CSV' -Product 'V4TAC' -Url:$CsvUrl -FullFilePath "$cache/$_"
         }
         "ip-intelligence-evidence.yml" {
-            Get-FromGitHub -Url "https://raw.githubusercontent.com/51Degrees/ip-intelligence-data/main/evidence.yml" -Output $cache/$_
+            & $PSScriptRoot/download-with-retry.ps1 -Url "https://raw.githubusercontent.com/51Degrees/ip-intelligence-data/main/evidence.yml" -Output $cache/$_ -MaxTime 600
         }
         "chargify.json" {
             Get-FromBulkData -License:$DeviceDetection -Data 'chargify' -Output $cache/$_

--- a/steps/fetch-assets.ps1
+++ b/steps/fetch-assets.ps1
@@ -44,6 +44,25 @@ function Get-FromBulkData {
     throw "No downloadable $Data version found in the last 30 days"
 }
 
+# Several assets are Git LFS objects (the Lite hash file alone is ~28MB) served
+# by GitHub's media host. When the whole build matrix pulls the same object at
+# once GitHub resets or stalls the connection, which failed the job outright
+# because a bare curl has no retry. Note that --retry on its own is not enough:
+# a reset (curl 35) is not in curl's default retry set, hence --retry-all-errors,
+# and --speed-limit/--speed-time turns a stalled transfer into a retry rather
+# than a hang that runs until the job is cancelled.
+function Get-FromGitHub {
+    param (
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][string]$Output
+    )
+    $retryArguments = @(
+        '--retry', 5, '--retry-all-errors', '--retry-delay', 5,
+        '--connect-timeout', 30, '--speed-limit', 1024, '--speed-time', 60
+    )
+    curl -fLo $Output @retryArguments $Url
+}
+
 foreach ($asset in $Assets) {
     if (Test-Path $cache/$asset) {
         Write-Host "Asset '$asset' already present in cache, skipping download"
@@ -56,7 +75,7 @@ foreach ($asset in $Assets) {
             Move-Item -Path $_ -Destination $cache
         }
         "51Degrees-LiteV4.1.hash" {
-            curl -fLo $cache/$_ "https://github.com/51Degrees/device-detection-data/raw/main/51Degrees-LiteV4.1.hash"
+            Get-FromGitHub -Url "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/51Degrees-LiteV4.1.hash" -Output $cache/$_
         }
         "51Degrees-EnterpriseIpiV41.ipi" {
             & $PSScriptRoot/fetch-hash-assets.ps1 -RepoName . -ArchiveName "$_.gz" -LicenseKey $IpIntelligence -DataType IPIV41 -Product IPIV4Enterprise -Url $IpIntelligenceUrl
@@ -73,10 +92,10 @@ foreach ($asset in $Assets) {
 
         }
         "20000 Evidence Records.yml" {
-            curl -fLo $cache/$_ "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/20000%20Evidence%20Records.yml"
+            Get-FromGitHub -Url "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/20000%20Evidence%20Records.yml" -Output $cache/$_
         }
         "20000 User Agents.csv" {
-            curl -fLo $cache/$_ "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/20000%20User%20Agents.csv"
+            Get-FromGitHub -Url "https://media.githubusercontent.com/media/51Degrees/device-detection-data/main/20000%20User%20Agents.csv" -Output $cache/$_
         }
         "51Degrees.csv" {
             & $PSScriptRoot/download-data-file.ps1 -LicenseKey:$DeviceDetection -DataType 'CSV' -Product 'V4TAC' -Url:$CsvUrl -FullFilePath "$_.zip"
@@ -92,7 +111,7 @@ foreach ($asset in $Assets) {
             & $PSScriptRoot/download-data-file.ps1 -LicenseKey:$DeviceDetection -DataType 'CSV' -Product 'V4TAC' -Url:$CsvUrl -FullFilePath "$cache/$_"
         }
         "ip-intelligence-evidence.yml" {
-            curl -fLo $cache/$_ "https://raw.githubusercontent.com/51Degrees/ip-intelligence-data/main/evidence.yml"
+            Get-FromGitHub -Url "https://raw.githubusercontent.com/51Degrees/ip-intelligence-data/main/evidence.yml" -Output $cache/$_
         }
         "chargify.json" {
             Get-FromBulkData -License:$DeviceDetection -Data 'chargify' -Output $cache/$_


### PR DESCRIPTION
Fixes #221. Nightly ip-intelligence-java run 32327632917 failed in fetch-assets.ps1 with 'curl: (35) Send failure: Connection was reset' while fetching the ~28MB Lite hash LFS object; the remaining Windows and macOS jobs were cancelled while stuck on the same download. Adds a Get-FromGitHub helper that retries with --retry-all-errors (curl 35 is not in curl's default retry set) and aborts stalled transfers via --speed-limit/--speed-time so they retry instead of hanging. Also switches the Lite hash to media.githubusercontent.com, matching the other LFS assets. Verified: script parses clean and the helper downloads successfully against a live URL.