### PR TITLE
Forward both halves of Pearl's S3 credentials to the publish workflows

### DIFF
--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -81,6 +81,9 @@ on:
       DockerRegistry:
       DockerUser:
       PearlLicense:
+      PearlUsageOvhEu:
+      PearlUsageOvhUs:
+      PearlUsageHetzner:
 
 defaults:
   run:

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -81,9 +81,12 @@ on:
       DockerRegistry:
       DockerUser:
       PearlLicense:
-      PearlUsageOvhEu:
-      PearlUsageOvhUs:
-      PearlUsageHetzner:
+      PearlHetznerS3AccessKeyId:
+      PearlHetznerS3SecretAccessKey:
+      PearlOvhEuS3AccessKeyId:
+      PearlOvhEuS3SecretAccessKey:
+      PearlOvhUsS3AccessKeyId:
+      PearlOvhUsS3SecretAccessKey:
 
 defaults:
   run:

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -78,6 +78,9 @@ on:
       DockerRegistry:
       DockerUser:
       PearlLicense:
+      PearlUsageOvhEu:
+      PearlUsageOvhUs:
+      PearlUsageHetzner:
 
 defaults:
   run:

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -78,9 +78,12 @@ on:
       DockerRegistry:
       DockerUser:
       PearlLicense:
-      PearlUsageOvhEu:
-      PearlUsageOvhUs:
-      PearlUsageHetzner:
+      PearlHetznerS3AccessKeyId:
+      PearlHetznerS3SecretAccessKey:
+      PearlOvhEuS3AccessKeyId:
+      PearlOvhEuS3SecretAccessKey:
+      PearlOvhUsS3AccessKeyId:
+      PearlOvhUsS3SecretAccessKey:
 
 defaults:
   run:


### PR DESCRIPTION
Pearl bakes the S3 credentials for its OVH and Hetzner usage buckets into the published image at build time, so `ci/build-package.ps1` needs them in the options it receives. Each credential is held as two repository values - the access key id as a variable, the secret access key as a secret - hence six declarations rather than three.

- `nightly-publish-main.yml`, `nightly-publish.yml`: declare `PearlHetznerS3AccessKeyId`, `PearlHetznerS3SecretAccessKey`, `PearlOvhEuS3AccessKeyId`, `PearlOvhEuS3SecretAccessKey`, `PearlOvhUsS3AccessKeyId`, `PearlOvhUsS3SecretAccessKey`.

Only the publish workflows run `build-package.ps1`, so the pull request workflows are left alone. The access key ids are variables rather than secrets, but are forwarded through the same block because the reusable workflows take no arbitrary inputs.

Must merge before the Pearl side, which fails workflow validation while these are undeclared.